### PR TITLE
feat(bundle): reduce size (WH-1098)

### DIFF
--- a/lib/components/Table/hooks/usePageSize.ts
+++ b/lib/components/Table/hooks/usePageSize.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import Utils from '../../../utils'
+import Utils from 'utils'
 import { ExtendedTable } from '../types'
 import { ROWS_PER_PAGE_RATIO, ROW_HEIGHT } from '../tableConsts'
 

--- a/lib/components/Table/hooks/usePageSize.ts
+++ b/lib/components/Table/hooks/usePageSize.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import debounce from 'lodash/debounce'
+import Utils from '../../../utils'
 import { ExtendedTable } from '../types'
 import { ROWS_PER_PAGE_RATIO, ROW_HEIGHT } from '../tableConsts'
 
@@ -27,7 +27,7 @@ function usePageSize<Data>({
       return
     }
 
-    const calcNumberOfRows = debounce(() => {
+    const calcNumberOfRows = Utils.debounce(() => {
       const tableHeight = tableRef.current?.clientHeight
       if (tableHeight) {
         table.setPageSize(tableHeight / (ROW_HEIGHT / ROWS_PER_PAGE_RATIO))

--- a/lib/components/Table/hooks/usePageSize.ts
+++ b/lib/components/Table/hooks/usePageSize.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
+import debounce from 'lodash/debounce'
 import { ExtendedTable } from '../types'
 import { ROWS_PER_PAGE_RATIO, ROW_HEIGHT } from '../tableConsts'
-import _ from 'lodash'
 
 function usePageSize<Data>({
   table,
@@ -27,7 +27,7 @@ function usePageSize<Data>({
       return
     }
 
-    const calcNumberOfRows = _.debounce(() => {
+    const calcNumberOfRows = debounce(() => {
       const tableHeight = tableRef.current?.clientHeight
       if (tableHeight) {
         table.setPageSize(tableHeight / (ROW_HEIGHT / ROWS_PER_PAGE_RATIO))

--- a/lib/components/TextEditor/components/TextViewerLite/hooks/useScrolledX.ts
+++ b/lib/components/TextEditor/components/TextViewerLite/hooks/useScrolledX.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import Utils from '../../../../../utils'
+import Utils from 'utils'
 
 function useScrolledX({ element }: { element: HTMLDivElement | null }) {
   const [isScrolledX, setScrolledX] = useState<boolean>(false)

--- a/lib/components/TextEditor/components/TextViewerLite/hooks/useScrolledX.ts
+++ b/lib/components/TextEditor/components/TextViewerLite/hooks/useScrolledX.ts
@@ -1,5 +1,5 @@
-import { debounce } from 'lodash'
 import { useEffect, useState } from 'react'
+import debounce from 'lodash/debounce'
 
 function useScrolledX({ element }: { element: HTMLDivElement | null }) {
   const [isScrolledX, setScrolledX] = useState<boolean>(false)

--- a/lib/components/TextEditor/components/TextViewerLite/hooks/useScrolledX.ts
+++ b/lib/components/TextEditor/components/TextViewerLite/hooks/useScrolledX.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
-import debounce from 'lodash/debounce'
+import Utils from '../../../../../utils'
 
 function useScrolledX({ element }: { element: HTMLDivElement | null }) {
   const [isScrolledX, setScrolledX] = useState<boolean>(false)
 
   useEffect(() => {
-    const handleScroll = debounce(() => {
+    const handleScroll = Utils.debounce(() => {
       if (element && element.scrollLeft > 0) {
         setScrolledX(true)
       } else {

--- a/lib/components/ToasterDialog/ToasterDialog.tsx
+++ b/lib/components/ToasterDialog/ToasterDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react'
 import clsx from 'clsx'
-import capitalize from 'lodash/capitalize'
 import { DIALOG_STATUSES, TOASTER_DIALOG } from 'consts'
 import { useDialog } from 'context'
 import Utils from 'utils'
@@ -40,7 +39,7 @@ function ToasterDialog() {
             })}
           >
             {status === DIALOG_STATUSES.SUCCESS ? <Approve /> : <Warning />}
-            {capitalize(status)}
+            {Utils.capitalize(status)}
           </div>
         ),
         body: message,

--- a/lib/components/ToasterDialog/ToasterDialog.tsx
+++ b/lib/components/ToasterDialog/ToasterDialog.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react'
 import clsx from 'clsx'
-import { capitalize } from 'lodash'
+import capitalize from 'lodash/capitalize'
 import { DIALOG_STATUSES, TOASTER_DIALOG } from 'consts'
-import { useDialog } from '../../context'
+import { useDialog } from 'context'
 import Utils from 'utils'
 import { Approve, Warning } from 'svgs'
 

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -389,6 +389,26 @@ const utils = {
       }
     })
     return isPast ? `${stringToShow} ago` : `in ${stringToShow}`
+  },
+
+  capitalize: (str: string) => {
+    const separator = ', '
+
+    return str
+      .split(separator)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(separator)
+  },
+
+  debounce: (callback: any, wait = 0) => {
+    let timer: ReturnType<typeof setTimeout> | -1 = -1
+
+    return (...args) => {
+      clearTimeout(timer)
+      timer = setTimeout(() => {
+        callback.apply(this, args)
+      }, wait)
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "check-password-strength": "^2.0.7",
     "clsx": "^2.0.0",
     "copy-to-clipboard": "^3.3.3",
-    "lodash": "^4.17.21",
     "luxon": "^3.4.4",
     "react-ace": "^12.0.0",
     "react-router-dom": "^6.25.0",


### PR DESCRIPTION
 For some reason tree shaking doesn't seem to work for `lodash` imports. Making direct imports reduced JS bundle size from `1347kB` to `1229kB`. More then 85% of bundle are external dependencies. Around half of bundle is taken by `react-ace` dependency.
 It might be possible to reduce css bundle, via moving font to CDN urls. Without font in base64 format in final bundle it is only around `100kB`, but with them - `579kB`.

<img width="731" alt="before" src="https://github.com/user-attachments/assets/94d09e4b-bba8-496e-9ab3-d06ec69ac669">
<img width="724" alt="after" src="https://github.com/user-attachments/assets/9aa76798-f1a3-4623-bdf3-e67378708e9e">

