### PR TITLE
fix(ToasterDialog, DarkModeSwitch): use relative import for context

### DIFF
--- a/lib/components/DarkModeSwitch/DarkModeSwitch.tsx
+++ b/lib/components/DarkModeSwitch/DarkModeSwitch.tsx
@@ -1,6 +1,6 @@
 import React, { useId, useState } from 'react'
 import clsx from 'clsx'
-import { useDarkMode } from 'context'
+import { useDarkMode } from '../../context'
 
 import './darkModeSwitch.scss'
 import Tooltip from '../Tooltip'

--- a/lib/components/ToasterDialog/ToasterDialog.tsx
+++ b/lib/components/ToasterDialog/ToasterDialog.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react'
 import clsx from 'clsx'
 import { DIALOG_STATUSES, TOASTER_DIALOG } from 'consts'
-import { useDialog } from 'context'
 import Utils from 'utils'
 import { Approve, Warning } from 'svgs'
+import { useDialog } from '../../context'
 
 import './toasterDialog.scss'
 


### PR DESCRIPTION
For some reason using alias import breaks `wekapp`:
<img width="821" alt="Screenshot 2024-11-20 at 09 12 12" src="https://github.com/user-attachments/assets/b090f075-fdb8-4362-96e9-45aa0f2f95a7">

And using relative import fixes this issue. Atm I don't have many ideas on the reason behind it.