### PR TITLE
fix: Align table row in case of partial expanded rows

### DIFF
--- a/lib/components/Table/components/TableRow/TableRow.tsx
+++ b/lib/components/Table/components/TableRow/TableRow.tsx
@@ -55,7 +55,7 @@ function TableRow<Data, Value>(props: TableRowProps<Data, Value>) {
   const classes = clsx({
     'table-line': true,
     clickable: onRowClick || isExpandable,
-    'is-expand': !row.getIsGrouped() && row.getIsExpanded(),
+    'is-expand': !row.getIsGrouped() && isRowExpanded,
     'is-selected': checkRowSelected?.(row.original),
     'is-highlighted': checkRowHighlighted?.(row.original),
     ...(extraClasses?.tableLine && {
@@ -66,12 +66,15 @@ function TableRow<Data, Value>(props: TableRowProps<Data, Value>) {
   return (
     <React.Fragment key={row.id}>
       <tr className={classes}>
-        {rowCanExpand && !grouping && (
-          <td
-            className={clsx('expand-cell', extraClasses?.expandCell)}
-            onClick={row.getToggleExpandedHandler()}
-          >
-            {isRowExpanded ? <Arrow /> : <Arrow className='rotate270' />}
+        {!grouping && (
+          <td className={clsx('expand-cell', extraClasses?.expandCell)}>
+            {rowCanExpand ? (
+              <div onClick={row.getToggleExpandedHandler()}>
+                {isRowExpanded ? <Arrow /> : <Arrow className='rotate270' />}
+              </div>
+            ) : (
+              <div className='expand-placeholder' />
+            )}
           </td>
         )}
         {row.getVisibleCells().map((cell, index) => (

--- a/lib/components/Table/table.scss
+++ b/lib/components/Table/table.scss
@@ -293,6 +293,12 @@
         }
       }
 
+      .expand-placeholder {
+        width: 8px;
+        height: 8px;
+        visibility: hidden;
+      }
+
       .expand-group {
         margin-right: 8px;
       }


### PR DESCRIPTION
Before
![Screenshot 2025-02-04 at 18 29 21](https://github.com/user-attachments/assets/a234ed9d-9bee-4345-9e09-02d0c16b00ab)


After 
![image](https://github.com/user-attachments/assets/357515ef-b2dc-4117-b466-a9e296692916)
