### PR TITLE
feat: add autoClose prop to utils. toastError (WEKAPP-268284)

### DIFF
--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -129,7 +129,8 @@ const utils = {
   toastError: (
     err?: string | Error | unknown,
     type?: (typeof TOASTER_TYPES)[keyof typeof TOASTER_TYPES],
-    toastId?: string
+    toastId?: string,
+    autoClose = 5000
   ) => {
     let message = 'Something went wrong'
 
@@ -164,13 +165,15 @@ const utils = {
           toast.error(<Toast message={message} icon={<Warning />} />, {
             position: toast.POSITION.BOTTOM_CENTER,
             icon: false,
-            toastId
+            toastId,
+            autoClose
           })
         }
       } else {
         toast.error(<Toast message={message} icon={<Warning />} />, {
           position: toast.POSITION.BOTTOM_CENTER,
-          icon: false
+          icon: false,
+          autoClose
         })
       }
     } else {
@@ -182,16 +185,30 @@ const utils = {
   },
   toastSuccess: (
     message: string,
-    type?: (typeof TOASTER_TYPES)[keyof typeof TOASTER_TYPES]
+    type?: (typeof TOASTER_TYPES)[keyof typeof TOASTER_TYPES],
+    toastId?: string,
+    autoClose = 5000
   ) => {
     if (
       (type !== TOASTER_TYPES.DIALOG && message.length < 100) ||
       type === TOASTER_TYPES.TOAST
     ) {
-      toast.success(<Toast message={message} icon={<Approve />} />, {
-        position: toast.POSITION.BOTTOM_CENTER,
-        icon: false
-      })
+      if (toastId) {
+        if (!toast.isActive(toastId)) {
+          toast.success(<Toast message={message} icon={<Approve />} />, {
+            position: toast.POSITION.BOTTOM_CENTER,
+            icon: false,
+            toastId,
+            autoClose
+          })
+        }
+      } else {
+        toast.success(<Toast message={message} icon={<Approve />} />, {
+          position: toast.POSITION.BOTTOM_CENTER,
+          icon: false,
+          autoClose
+        })
+      }
     } else {
       utils.dispatchCustomEvent(TOASTER_DIALOG, {
         status: DIALOG_STATUSES.SUCCESS,


### PR DESCRIPTION
In wekapp on Events page there are a lot of requests and default timer isn't enough to show only one Toast per same error.