### PR TITLE
fix(build): rename CSS Modules in writeBundle for Vite 8 / Rolldown

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import dts from 'vite-plugin-dts'
-import { resolve } from 'path'
+import { resolve, join } from 'path'
+import { renameSync } from 'fs'
 import { libInjectCss } from 'vite-plugin-lib-inject-css'
 import svgr from 'vite-plugin-svgr'
 import tsconfigPaths from 'vite-tsconfig-paths'
@@ -55,19 +56,24 @@ function isExternalImport(source: string, importer: string | undefined) {
 /**
  * Renames `.module.css` assets to `.css` in the build output so that consuming
  * bundlers don't drop or re-process them — the class names are already hashed.
+ *
+ * Splits the work across two hooks because Vite 8 / Rolldown ignores bundle
+ * mutations in `generateBundle`. Chunk code is still rewritten in
+ * `generateBundle` (so the injected `import` statements point at `.css`), and
+ * the actual asset files are renamed on disk in `writeBundle` after Rolldown
+ * has finished emitting them.
  */
 function stripCssModuleExtension(): Plugin {
+  const moduleCssFiles: string[] = []
+
   return {
     name: 'strip-css-module-extension',
     enforce: 'post',
     generateBundle(_, bundle) {
+      moduleCssFiles.length = 0
       for (const fileName of Object.keys(bundle)) {
         if (fileName.endsWith('.module.css')) {
-          const newFileName = fileName.replace('.module.css', '.css')
-          const asset = bundle[fileName]
-          asset.fileName = newFileName
-          bundle[newFileName] = asset
-          delete bundle[fileName]
+          moduleCssFiles.push(fileName)
         }
       }
 
@@ -75,6 +81,16 @@ function stripCssModuleExtension(): Plugin {
         if (chunk.type === 'chunk' && chunk.code.includes('.module.css')) {
           chunk.code = chunk.code.split('.module.css').join('.css')
         }
+      }
+    },
+    writeBundle(options) {
+      const outDir = options.dir
+      if (!outDir) {
+        return
+      }
+      for (const fileName of moduleCssFiles) {
+        const newFileName = fileName.replace('.module.css', '.css')
+        renameSync(join(outDir, fileName), join(outDir, newFileName))
       }
     }
   }


### PR DESCRIPTION
Vite 8 switched to Rolldown, which ignores bundle mutations in generateBundle. The .module.css → .css rename was silently dropped, so v2 chunks shipped imports to non-existent CSS files. Move the rename to writeBundle (fs.renameSync), keep chunk-code rewriting in generateBundle