### PR TITLE
fix(colors): sync orange-600 and AlertBadge info background with Figma (WH-4052)

### DIFF
--- a/lib/v2/components/AlertBadge/alertBadge.module.scss
+++ b/lib/v2/components/AlertBadge/alertBadge.module.scss
@@ -28,7 +28,7 @@
 }
 
 .info {
-  background: var(--gray-200-800);
+  background: var(--gray-150-850);
   color: var(--gray-900-100);
 }
 

--- a/lib/v2/styles/colors.scss
+++ b/lib/v2/styles/colors.scss
@@ -117,7 +117,7 @@ $orange-950: #331d00;
 $orange-900: #4d2b00;
 $orange-800: #734000;
 $orange-700: #995600;
-$orange-600: #bf6b00;
+$orange-600: #cc7200;
 $orange-500: #e58b17;
 $orange-400: #ffab40;
 $orange-300: #ffbc66;

--- a/lib/v2/styles/gradientColors.ts
+++ b/lib/v2/styles/gradientColors.ts
@@ -8,7 +8,7 @@ export const GRADIENT_COLORS = {
     end: '#59B267'
   },
   orange: {
-    start: '#BF6B00',
+    start: '#CC7200',
     end: '#FFAB40'
   },
   yellow: {


### PR DESCRIPTION
## Summary

Sync palette colors with the Design System 2025 Figma (node 1839:10056).

- `$orange-600`: `#bf6b00` → `#cc7200` to match Figma `Orange/600`
- orange gradient `start`: `#BF6B00` → `#CC7200` (keeps the gradient in sync with the token)
- `AlertBadge` `.info` background: `--gray-200-800` → `--gray-150-850`

## Verification

Checked against Figma variable definitions:

| Change | New value | Figma |
|---|---|---|
| `$orange-600` | `#cc7200` | `Orange/600` `#cc7200` ✓ |
| orange gradient start | `#CC7200` | `Orange/600` `#cc7200` ✓ |
| `.info` bg `--gray-150-850` | `#cfd9e5` / `#252c33` | `Gray/150` / `Gray/850` ✓ |

The full Gray (23 shades) and Red (12 shades) scales were also confirmed to match Figma exactly.

## Severity → token mapping (unchanged, confirmed aligned)

| Severity | Token |
|---|---|
| critical | `red-700` |
| major | `red-500` |
| minor | `orange-600` |
| warning | `yellow-600` |
| info | `gray-150-850` |

## Out of scope (follow-up)

The Yellow scale (incl. `yellow-600`, used by the `warning` badge) and remaining Orange shades (500/700/800/900/950) also differ from current Figma — left for a separate palette-sync ticket.

## Release

`patch` label applied → patch version bump on merge.

## Testing
- `yarn typecheck` clean on changed files
- `yarn test:run` → 611/611 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)