### PR TITLE
feat(colors): add aqua/blue/aubergine to v2 palette, set aqua to new Figma values (WH-4094)

### DIFF
--- a/lib/v2/styles/colors.scss
+++ b/lib/v2/styles/colors.scss
@@ -139,3 +139,45 @@ $yellow-200: #fff099;
 $yellow-100: #fff4b2;
 $yellow-50: #fff8cc;
 $yellow-20: #fffde5;
+
+// Aqua Brand Colors
+$aqua-950: #003033;
+$aqua-900: #00494c;
+$aqua-800: #056166;
+$aqua-700: #0d7a80;
+$aqua-600: #0f9299;
+$aqua-500: #12aab2;
+$aqua-400: #14c3cc;
+$aqua-300: #17dbe6;
+$aqua-200: #30e9f2;
+$aqua-100: #99faff;
+$aqua-50: #ccfcff;
+$aqua-20: #e5fdff;
+
+// Blue Brand Colors
+$blue-950: #060826;
+$blue-900: #0a1340;
+$blue-800: #0f1e66;
+$blue-700: #15298c;
+$blue-600: #1b34b2;
+$blue-500: #334dcc;
+$blue-400: #4560e5;
+$blue-300: #6179f2;
+$blue-200: #8095ff;
+$blue-100: #99aaff;
+$blue-50: #ccd5ff;
+$blue-20: #e5eaff;
+
+// Aubergine Brand Colors
+$aubergine-950: #06030d;
+$aubergine-900: #0c081a;
+$aubergine-800: #1b1233;
+$aubergine-700: #2b1f4d;
+$aubergine-600: #413366;
+$aubergine-500: #5a4d80;
+$aubergine-400: #3a185a;
+$aubergine-300: #4b2370;
+$aubergine-200: #aea3cc;
+$aubergine-100: #d5cfe5;
+$aubergine-50: #e0daf2;
+$aubergine-20: #f2edfa;


### PR DESCRIPTION
## WH-4094 — Aqua color set + v2 palette consolidation

Patch-only change: **new color tokens only**, no behavioral or API changes.

### Changes (`lib/v2/styles/colors.scss`)
- **Aqua** updated to the new Figma values (brighter cyan-teal):

  | Stop | Old | New |
  |---|---|---|
  | 950 | `#00191a` | `#003033` |
  | 900 | `#022626` | `#00494c` |
  | 800 | `#083233` | `#056166` |
  | 700 | `#0f4c4d` | `#0d7a80` |
  | 600 | `#1f6566` | `#0f9299` |
  | 500 | `#337f80` | `#12aab2` |
  | 400 | `#4d9899` | `#14c3cc` |
  | 300 | `#59b1b2` | `#17dbe6` |
  | 200 | `#7acbcc` | `#30e9f2` |
  | 100 | `#b8e5e5` | `#99faff` |
  | 50  | `#e5ffff` | `#ccfcff` |
  | 20  | `#f2ffff` | `#e5fdff` |

- **Blue** and **Aubergine** families added so the v2 palette fully matches the Observe palette — this lets Observe (and future apps) source **all** color tokens from the library via `@forward`, making palette drift structurally impossible.

### Notes
- Additive `$`-token change only (+42 lines); no existing token values other than aqua change.
- Values were read from Figma (Design System 2025) and confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)