### PR TITLE
fix(v2): Select menu upward placement + solid severity colors

### DIFF
--- a/lib/v2/components/AlertBadge/alertBadge.module.scss
+++ b/lib/v2/components/AlertBadge/alertBadge.module.scss
@@ -17,9 +17,8 @@
 }
 
 .minor {
-  @extend %severity-base;
-
-  background: $orange-600;
+  background: $orange-400;
+  color: $gray-950;
 }
 
 .warning {

--- a/lib/v2/components/inputs/Select/Select.test.tsx
+++ b/lib/v2/components/inputs/Select/Select.test.tsx
@@ -33,11 +33,13 @@ const SEARCH_THRESHOLD_OPTIONS = 15
 const MAX_VISIBLE_CHIPS = 2
 const REMAINING_INDICATOR = '+1'
 const MENU_PAPER_UP_CLASS = 'menuPaperUp'
+const SELECT_FIELD_CLASS = 'select'
 const VIEWPORT_HEIGHT = 800
 const SPACE_BELOW_TOO_SMALL = 10
 const SPACE_ABOVE_LARGE = 780
 const SPACE_BELOW_LARGE = 740
 const SPACE_ABOVE_SMALL = 40
+const FORM_CONTROL_TOP_WITH_LABEL = 0
 
 const mockOptions: SelectOption[] = [
   { value: 'option1', label: OPTION_1 },
@@ -586,5 +588,36 @@ describe('Select - Menu placement', () => {
     expect(
       document.querySelector(`.${MENU_PAPER_UP_CLASS}`)
     ).not.toBeInTheDocument()
+  })
+
+  it('measures the select field, not the label, when deciding placement', async () => {
+    const fieldBottom = VIEWPORT_HEIGHT - SPACE_BELOW_TOO_SMALL
+    rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const isField = this.classList.contains(SELECT_FIELD_CLASS)
+        const top = isField ? SPACE_ABOVE_LARGE : FORM_CONTROL_TOP_WITH_LABEL
+        return {
+          top,
+          bottom: fieldBottom,
+          left: 0,
+          right: 0,
+          width: 0,
+          height: fieldBottom - top,
+          x: 0,
+          y: top,
+          toJSON: () => ({})
+        } as DOMRect
+      })
+    render(<Select {...createProps({ label: LABEL_TEXT })} />)
+
+    openSelect()
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+    expect(
+      document.querySelector(`.${MENU_PAPER_UP_CLASS}`)
+    ).toBeInTheDocument()
   })
 })

--- a/lib/v2/components/inputs/Select/Select.test.tsx
+++ b/lib/v2/components/inputs/Select/Select.test.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   waitFor
 } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   EMPTY_STRING,
@@ -32,6 +32,12 @@ const ANY_VALUE = 'any'
 const SEARCH_THRESHOLD_OPTIONS = 15
 const MAX_VISIBLE_CHIPS = 2
 const REMAINING_INDICATOR = '+1'
+const MENU_PAPER_UP_CLASS = 'menuPaperUp'
+const VIEWPORT_HEIGHT = 800
+const SPACE_BELOW_TOO_SMALL = 10
+const SPACE_ABOVE_LARGE = 780
+const SPACE_BELOW_LARGE = 740
+const SPACE_ABOVE_SMALL = 40
 
 const mockOptions: SelectOption[] = [
   { value: 'option1', label: OPTION_1 },
@@ -513,5 +519,72 @@ describe('Select - Empty state', () => {
     await waitFor(() => {
       expect(screen.getByText(NO_OPTIONS_TEXT)).toBeInTheDocument()
     })
+  })
+})
+
+describe('Select - Menu placement', () => {
+  let rectSpy: ReturnType<typeof vi.spyOn> | undefined
+  let originalInnerHeight: number
+
+  const mockControlSpace = (spaceAbove: number, spaceBelow: number) => {
+    const top = spaceAbove
+    const bottom = VIEWPORT_HEIGHT - spaceBelow
+    rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({
+        top,
+        bottom,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: bottom - top,
+        x: 0,
+        y: top,
+        toJSON: () => ({})
+      } as DOMRect)
+  }
+
+  beforeEach(() => {
+    originalInnerHeight = window.innerHeight
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: VIEWPORT_HEIGHT
+    })
+  })
+
+  afterEach(() => {
+    rectSpy?.mockRestore()
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: originalInnerHeight
+    })
+  })
+
+  it('opens the menu upward when there is not enough space below', async () => {
+    mockControlSpace(SPACE_ABOVE_LARGE, SPACE_BELOW_TOO_SMALL)
+    render(<Select {...createProps()} />)
+
+    openSelect()
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+    expect(
+      document.querySelector(`.${MENU_PAPER_UP_CLASS}`)
+    ).toBeInTheDocument()
+  })
+
+  it('opens the menu downward when there is enough space below', async () => {
+    mockControlSpace(SPACE_ABOVE_SMALL, SPACE_BELOW_LARGE)
+    render(<Select {...createProps()} />)
+
+    openSelect()
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+    expect(
+      document.querySelector(`.${MENU_PAPER_UP_CLASS}`)
+    ).not.toBeInTheDocument()
   })
 })

--- a/lib/v2/components/inputs/Select/Select.tsx
+++ b/lib/v2/components/inputs/Select/Select.tsx
@@ -126,6 +126,7 @@ export function Select({
   const [openUpward, setOpenUpward] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(NO_HIGHLIGHT)
   const formControlRef = useRef<HTMLDivElement | null>(null)
+  const selectFieldRef = useRef<HTMLDivElement | null>(null)
   const menuPaperRef = useRef<HTMLDivElement | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -273,7 +274,9 @@ export function Select({
   }
 
   const handleMenuOpen = () => {
-    const rect = formControlRef.current?.getBoundingClientRect()
+    const rect = (
+      selectFieldRef.current ?? formControlRef.current
+    )?.getBoundingClientRect()
     const spaceBelow = rect ? window.innerHeight - rect.bottom : Infinity
     const spaceAbove = rect ? rect.top : 0
     setOpenUpward(spaceBelow < MENU_MAX_HEIGHT && spaceAbove > spaceBelow)
@@ -499,6 +502,7 @@ export function Select({
         </label>
       ) : null}
       <MuiSelect
+        ref={selectFieldRef}
         className={clsx(styles.select, multiple && styles.selectMultiple)}
         data-testid={dataTestId}
         displayEmpty

--- a/lib/v2/components/inputs/Select/Select.tsx
+++ b/lib/v2/components/inputs/Select/Select.tsx
@@ -274,17 +274,16 @@ export function Select({
 
   const handleMenuOpen = () => {
     const rect = formControlRef.current?.getBoundingClientRect()
-    if (rect) {
-      const spaceBelow = window.innerHeight - rect.bottom
-      const spaceAbove = rect.top
-      setOpenUpward(spaceBelow < MENU_MAX_HEIGHT && spaceAbove > spaceBelow)
-    }
+    const spaceBelow = rect ? window.innerHeight - rect.bottom : Infinity
+    const spaceAbove = rect ? rect.top : 0
+    setOpenUpward(spaceBelow < MENU_MAX_HEIGHT && spaceAbove > spaceBelow)
     setIsOpen(true)
     setSearchQuery(EMPTY_STRING)
   }
 
   const handleMenuClose = useCallback(() => {
     setIsOpen(false)
+    setOpenUpward(false)
     setSearchQuery(EMPTY_STRING)
     setHighlightedIndex(NO_HIGHLIGHT)
   }, [])

--- a/lib/v2/components/inputs/Select/Select.tsx
+++ b/lib/v2/components/inputs/Select/Select.tsx
@@ -35,6 +35,7 @@ import styles from './select.module.scss'
 const DEFAULT_SEARCH_THRESHOLD = 8
 const DEFAULT_SEARCH_DEBOUNCE_MS = 300
 const DEFAULT_MIN_SEARCH_LENGTH = 2
+const MENU_MAX_HEIGHT = 300
 const SEARCH_FOCUS_DELAY_MS = 100
 const NO_HIGHLIGHT = -1
 const CHEVRON_ICON_SIZE = 16
@@ -122,6 +123,7 @@ export function Select({
 }: Readonly<SelectProps>) {
   const [searchQuery, setSearchQuery] = useState(EMPTY_STRING)
   const [isOpen, setIsOpen] = useState(false)
+  const [openUpward, setOpenUpward] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(NO_HIGHLIGHT)
   const formControlRef = useRef<HTMLDivElement | null>(null)
   const menuPaperRef = useRef<HTMLDivElement | null>(null)
@@ -271,6 +273,12 @@ export function Select({
   }
 
   const handleMenuOpen = () => {
+    const rect = formControlRef.current?.getBoundingClientRect()
+    if (rect) {
+      const spaceBelow = window.innerHeight - rect.bottom
+      const spaceAbove = rect.top
+      setOpenUpward(spaceBelow < MENU_MAX_HEIGHT && spaceAbove > spaceBelow)
+    }
     setIsOpen(true)
     setSearchQuery(EMPTY_STRING)
   }
@@ -512,7 +520,7 @@ export function Select({
         MenuProps={{
           PaperProps: {
             ref: menuPaperRef,
-            className: styles.menuPaper,
+            className: clsx(styles.menuPaper, openUpward && styles.menuPaperUp),
             onKeyDown: handleKeyDown
           },
           MenuListProps: {
@@ -522,11 +530,11 @@ export function Select({
           disableAutoFocusItem: true,
           disableScrollLock: true,
           anchorOrigin: {
-            vertical: 'bottom',
+            vertical: openUpward ? 'top' : 'bottom',
             horizontal: 'left'
           },
           transformOrigin: {
-            vertical: 'top',
+            vertical: openUpward ? 'bottom' : 'top',
             horizontal: 'left'
           }
         }}

--- a/lib/v2/components/inputs/Select/select.module.scss
+++ b/lib/v2/components/inputs/Select/select.module.scss
@@ -172,6 +172,11 @@
   overflow: hidden !important;
 }
 
+.menuPaperUp {
+  margin-top: 0 !important;
+  margin-bottom: 4px !important;
+}
+
 .menuListWrapper {
   display: flex !important;
   flex-direction: column !important;

--- a/lib/v2/styles/_severity.scss
+++ b/lib/v2/styles/_severity.scss
@@ -2,29 +2,29 @@
 
 @mixin severity-colors {
   .critical {
-    background: linear-gradient(0deg, $red-800 0%, $red-600 100%);
+    background: $red-700;
     color: $gray-0;
   }
 
   .major {
-    background: linear-gradient(0deg, $red-500 0%, $red-300 100%);
+    background: $red-500;
     color: $gray-0;
   }
 
   .minor {
-    background: linear-gradient(0deg, $orange-600 0%, $orange-400 100%);
-    color: $gray-0;
+    background: $orange-400;
+    color: $gray-950;
   }
 
   .warning {
-    background: linear-gradient(0deg, $yellow-600 0%, $yellow-400 100%);
-    color: $gray-800;
+    background: $yellow-600;
+    color: $gray-950;
   }
 
   .debug,
   .default,
   .info {
-    background: linear-gradient(0deg, $gray-600 0%, $gray-400 100%);
+    background: $gray-500;
     color: $gray-0;
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "type": "module",
-  "version": "4.22.1",
+  "version": "4.22.2",
   "module": "lib/main.ts",
   "types": "lib/main.ts",
   "imports": {


### PR DESCRIPTION
## Summary

This PR bundles two related v2 styling/behavior changes (released together in v4.22.2):

### Select — upward menu placement
- Open the menu upward when there isn't enough room below (`MENU_MAX_HEIGHT` threshold) and there's more space above.
- `openUpward` is always recomputed on open (defaults to downward when the control rect is unavailable) and reset on close, so a stale value can't anchor the menu to the wrong side.
- Added tests stubbing `getBoundingClientRect`/`innerHeight` to assert upward flip with little space below and downward otherwise.

### Severity / Alert colors
- Dropped gradients across severities in `_severity.scss`; backgrounds now match `AlertBadge`'s solid values (critical `$red-700`, major `$red-500`, warning `$yellow-600`, debug/default/info `$gray-500`).
- **Minor (orange):** background `$orange-600` → `$orange-400`, foreground/icons `$gray-0` → `$gray-950`, per the Figma design system update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)