### PR TITLE
fix(table): keep at least one column visible in the column selector (WH-3334)

### DIFF
--- a/lib/v2/components/CheckBox/CheckBox.test.tsx
+++ b/lib/v2/components/CheckBox/CheckBox.test.tsx
@@ -218,3 +218,55 @@ describe('Checkbox', () => {
     })
   })
 })
+
+describe('Checkbox - disabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not call onChange when clicked while disabled', () => {
+    const handleChange = vi.fn()
+    render(
+      <Checkbox
+        checked
+        disabled
+        onChange={handleChange}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('custom-checkbox'))
+
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('does not call onChange on keyboard activation while disabled', () => {
+    const handleChange = vi.fn()
+    render(
+      <Checkbox
+        checked
+        disabled
+        onChange={handleChange}
+      />
+    )
+
+    const checkbox = screen.getByTestId('custom-checkbox')
+    fireEvent.keyDown(checkbox, { key: ' ' })
+    fireEvent.keyDown(checkbox, { key: 'Enter' })
+
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('exposes the disabled state through aria-disabled and tabIndex', () => {
+    render(
+      <Checkbox
+        checked
+        disabled
+        onChange={vi.fn()}
+      />
+    )
+
+    const checkbox = screen.getByTestId('custom-checkbox')
+    expect(checkbox).toHaveAttribute('aria-disabled', 'true')
+    expect(checkbox).toHaveAttribute('tabindex', '-1')
+  })
+})

--- a/lib/v2/components/CheckBox/CheckBox.tsx
+++ b/lib/v2/components/CheckBox/CheckBox.tsx
@@ -15,13 +15,15 @@ export interface CheckboxProps {
   onChange: (checked: boolean) => void
   wrapperClass?: string
   partiallyChecked?: boolean
+  disabled?: boolean
 }
 
 export function Checkbox({
   checked,
   onChange,
   partiallyChecked,
-  wrapperClass
+  wrapperClass,
+  disabled = false
 }: Readonly<CheckboxProps>) {
   function getIcon() {
     if (partiallyChecked) {
@@ -38,15 +40,22 @@ export function Checkbox({
   return (
     <div
       aria-checked={partiallyChecked ? 'mixed' : checked}
-      className={clsx(styles.checkbox, wrapperClass)}
+      aria-disabled={disabled}
+      className={clsx(styles.checkbox, disabled && styles.disabled, wrapperClass)}
       data-testid='custom-checkbox'
       role='checkbox'
-      tabIndex={0}
+      tabIndex={disabled ? -1 : 0}
       onClick={(event) => {
         event?.stopPropagation()
+        if (disabled) {
+          return
+        }
         onChange(!checked)
       }}
       onKeyDown={(event) => {
+        if (disabled) {
+          return
+        }
         if (
           event.key === KEYBOARD_KEYS.SPACE ||
           event.key === KEYBOARD_KEYS.ENTER

--- a/lib/v2/components/CheckBox/checkBox.module.scss
+++ b/lib/v2/components/CheckBox/checkBox.module.scss
@@ -8,3 +8,8 @@
     color: var(--gray-850-150);
   }
 }
+
+.disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}

--- a/lib/v2/components/Table/FilterOptionRow/FilterOptionRow.test.tsx
+++ b/lib/v2/components/Table/FilterOptionRow/FilterOptionRow.test.tsx
@@ -117,6 +117,37 @@ describe('FilterOptionRow - selection', () => {
   })
 })
 
+describe('FilterOptionRow - disabled', () => {
+  it('does not invoke onChange when the checkbox is clicked while disabled', () => {
+    const onChange = vi.fn()
+    render(
+      <FilterOptionRow
+        disabled
+        isSelected
+        label={OPTION_LABEL}
+        onChange={onChange}
+      />
+    )
+    fireEvent.click(screen.getByRole('checkbox'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('does not invoke onChange when the row is clicked while disabled', () => {
+    const onChange = vi.fn()
+    render(
+      <FilterOptionRow
+        dataTestId={OPTION_TEST_ID}
+        disabled
+        isSelected
+        label={OPTION_LABEL}
+        onChange={onChange}
+      />
+    )
+    fireEvent.click(screen.getByTestId(OPTION_TEST_ID))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
 describe('FilterOptionRow - highlighting', () => {
   it('wraps the matched substring in its own element when highlighting is enabled', () => {
     render(

--- a/lib/v2/components/Table/FilterOptionRow/FilterOptionRow.tsx
+++ b/lib/v2/components/Table/FilterOptionRow/FilterOptionRow.tsx
@@ -20,6 +20,7 @@ export interface FilterOptionRowProps {
   shouldHighlightMatches?: boolean
   dataOptionIndex?: number
   dataTestId?: string
+  disabled?: boolean
 }
 
 const HIGHLIGHT_ELEMENT = 'span'
@@ -34,7 +35,8 @@ export function FilterOptionRow({
   searchQuery,
   shouldHighlightMatches = false,
   dataOptionIndex,
-  dataTestId
+  dataTestId,
+  disabled = false
 }: Readonly<FilterOptionRowProps>) {
   const renderLabel = () => {
     if (shouldHighlightMatches && searchQuery) {
@@ -52,17 +54,22 @@ export function FilterOptionRow({
     <div
       data-option-index={dataOptionIndex}
       {...(dataTestId && { 'data-testid': dataTestId })}
-      tabIndex={0}
+      tabIndex={disabled ? -1 : 0}
       className={clsx(styles.filterOptionWrapper, {
-        [styles.hovered]: isHovered
+        [styles.hovered]: isHovered && !disabled,
+        [styles.disabled]: disabled
       })}
       onClick={(e) => {
         e.stopPropagation()
+        if (disabled) {
+          return
+        }
         onChange(isSelected)
       }}
     >
       <Checkbox
         checked={isSelected}
+        disabled={disabled}
         onChange={onChange}
       />
       {chipElement ? (

--- a/lib/v2/components/Table/FilterOptionRow/filterOptionRow.module.scss
+++ b/lib/v2/components/Table/FilterOptionRow/filterOptionRow.module.scss
@@ -19,6 +19,19 @@
   background-color: var(--bg-item-hover);
 }
 
+.disabled {
+  cursor: not-allowed;
+
+  &:hover,
+  &:active {
+    background-color: transparent;
+  }
+
+  .checkboxLabel {
+    color: var(--gray-600-400);
+  }
+}
+
 .checkboxLabel {
   flex: 1;
   min-width: 0;

--- a/lib/v2/components/Table/TableHeader/TableHeader.test.tsx
+++ b/lib/v2/components/Table/TableHeader/TableHeader.test.tsx
@@ -1,17 +1,42 @@
 import type { ActiveFilter } from '../filterUtils'
+import type { ComponentProps } from 'react'
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within
+} from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { FILTER_TYPES } from '#v2/utils/consts'
 
 import { TableHeader } from './TableHeader'
 
+type MockTable = ComponentProps<typeof TableHeader>['table']
+
+const createTableMock = (
+  columnVisibility: Record<string, boolean>,
+  setColumnVisibility = vi.fn()
+): MockTable =>
+  ({
+    getState: () => ({ columnVisibility }),
+    getFilteredRowModel: () => ({ rows: [] }),
+    setColumnVisibility
+  }) as unknown as MockTable
+
 const COLUMNS = [
   { accessorKey: 'name', header: 'Name' },
   { accessorKey: 'region', header: 'Region' }
 ]
 const SAMPLE_DATA = [{ name: 'a', region: 'us-east-1' }]
+const SETTINGS_BUTTON_TESTID = 'table-settings-button'
+const NAME_OPTION_TESTID = 'table-settings-column-option-name'
+const REGION_OPTION_TESTID = 'table-settings-column-option-region'
+const CHECKBOX_TESTID = 'custom-checkbox'
+const ARIA_DISABLED = 'aria-disabled'
+const ARIA_DISABLED_FALSE = 'false'
 const ACTIVE_FILTERS: ActiveFilter[] = [
   {
     columnId: 'region',
@@ -66,14 +91,74 @@ describe('TableHeader', () => {
         title='Clusters'
       />
     )
-    fireEvent.click(screen.getByTestId('table-settings-button'))
+    fireEvent.click(screen.getByTestId(SETTINGS_BUTTON_TESTID))
     expect(screen.getByTestId('table-settings-menu')).toBeInTheDocument()
-    expect(
-      screen.getByTestId('table-settings-column-option-name')
-    ).toBeInTheDocument()
-    expect(
-      screen.getByTestId('table-settings-column-option-region')
-    ).toBeInTheDocument()
+    expect(screen.getByTestId(NAME_OPTION_TESTID)).toBeInTheDocument()
+    expect(screen.getByTestId(REGION_OPTION_TESTID)).toBeInTheDocument()
+  })
+
+  it('disables the toggle for the only remaining visible column', () => {
+    render(
+      <TableHeader
+        columns={COLUMNS}
+        data={SAMPLE_DATA}
+        table={createTableMock({ region: false })}
+        title='Clusters'
+      />
+    )
+    fireEvent.click(screen.getByTestId(SETTINGS_BUTTON_TESTID))
+
+    const nameOption = screen.getByTestId(NAME_OPTION_TESTID)
+    const regionOption = screen.getByTestId(REGION_OPTION_TESTID)
+    expect(within(nameOption).getByTestId(CHECKBOX_TESTID)).toHaveAttribute(
+      ARIA_DISABLED,
+      'true'
+    )
+    expect(within(regionOption).getByTestId(CHECKBOX_TESTID)).toHaveAttribute(
+      ARIA_DISABLED,
+      ARIA_DISABLED_FALSE
+    )
+  })
+
+  it('does not hide the last visible column when its disabled toggle is clicked', () => {
+    const setColumnVisibility = vi.fn()
+    render(
+      <TableHeader
+        columns={COLUMNS}
+        data={SAMPLE_DATA}
+        table={createTableMock({ region: false }, setColumnVisibility)}
+        title='Clusters'
+      />
+    )
+    fireEvent.click(screen.getByTestId(SETTINGS_BUTTON_TESTID))
+
+    const nameOption = screen.getByTestId(NAME_OPTION_TESTID)
+    fireEvent.click(within(nameOption).getByTestId(CHECKBOX_TESTID))
+
+    expect(setColumnVisibility).not.toHaveBeenCalled()
+  })
+
+  it('keeps both toggles enabled while more than one column is visible', () => {
+    render(
+      <TableHeader
+        columns={COLUMNS}
+        data={SAMPLE_DATA}
+        table={createTableMock({})}
+        title='Clusters'
+      />
+    )
+    fireEvent.click(screen.getByTestId(SETTINGS_BUTTON_TESTID))
+
+    const nameOption = screen.getByTestId(NAME_OPTION_TESTID)
+    const regionOption = screen.getByTestId(REGION_OPTION_TESTID)
+    expect(within(nameOption).getByTestId(CHECKBOX_TESTID)).toHaveAttribute(
+      ARIA_DISABLED,
+      ARIA_DISABLED_FALSE
+    )
+    expect(within(regionOption).getByTestId(CHECKBOX_TESTID)).toHaveAttribute(
+      ARIA_DISABLED,
+      ARIA_DISABLED_FALSE
+    )
   })
 
   it('renders filter chips for active filters', () => {

--- a/lib/v2/components/Table/TableHeader/TableHeader.tsx
+++ b/lib/v2/components/Table/TableHeader/TableHeader.tsx
@@ -24,6 +24,7 @@ import styles from './tableHeader.module.scss'
 const SETTINGS_MENU_HEIGHT = 250
 const SETTINGS_MENU_MARGIN = 4
 const VISIBILITY_STATE_SYNC_DELAY = 50
+const MIN_VISIBLE_COLUMNS = 1
 const NAME_COLUMN_IDS = ['name', 'filename', 'clusterName']
 const MIN_SEARCH_LENGTH = 2
 const DOWNLOAD_ICON_SIZE = 28
@@ -486,6 +487,11 @@ export function TableHeader({
         }
       : undefined
 
+    const visibleColumnCount = columns.filter((col) => {
+      const columnId = getColumnId(col)
+      return columnId !== undefined && columnVisibility[columnId] !== false
+    }).length
+
     return (
       <div
         data-testid='table-settings-menu'
@@ -504,12 +510,17 @@ export function TableHeader({
             }
             const header =
               typeof col.header === 'string' ? col.header : columnId
+            const isSelected = columnVisibility[columnId] !== false
+
+            const isLastVisibleColumn =
+              isSelected && visibleColumnCount <= MIN_VISIBLE_COLUMNS
 
             return (
               <FilterOptionRow
                 key={columnId}
                 dataTestId={`table-settings-column-option-${columnId}`}
-                isSelected={columnVisibility[columnId] !== false}
+                disabled={isLastVisibleColumn}
+                isSelected={isSelected}
                 label={header}
                 onChange={() => handleColumnVisibilityToggle(columnId)}
               />


### PR DESCRIPTION
## What
De-selecting **every** column in the table's column-visibility menu left an empty table (WH-3334).

## Fix
Disable the toggle for whichever column is currently the **only one still visible**, so the user can never reach an empty table. The rule is dynamic — it protects whichever column happens to be last, not a fixed one.

- **`TableHeader.tsx`** — `renderSettingsMenu()` counts visible columns and passes `disabled` to the single remaining visible column's row.
- **`FilterOptionRow.tsx`** — new `disabled` prop: no-ops row/checkbox click, `tabIndex={-1}`, muted/`not-allowed` styling.
- **`CheckBox.tsx`** — new `disabled` prop: blocks click + keyboard handlers, sets `aria-disabled`, `tabIndex={-1}`, dimmed.

## Tests
Added coverage for `CheckBox`, `FilterOptionRow`, and `TableHeader` (disabled no-op behavior, last-visible-column disabling, and >1-visible staying enabled). 33 tests pass; CI diff-lint clean; no new typecheck errors in touched files.

## Follow-up for consumers
Observe (and other consumers) pick this up after a version bump once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)