### PR TITLE
fix(sidebar): overlay panel on expand instead of reflowing content

### DIFF
--- a/lib/v2/components/Sidebar/Sidebar.tsx
+++ b/lib/v2/components/Sidebar/Sidebar.tsx
@@ -45,49 +45,57 @@ export function Sidebar({
   )
 
   return (
-    <aside
-      className={clsx(styles.sidebar, isExpanded && styles.expanded, extraClass)}
-      data-testid={dataTestId}
-    >
-      <button
-        aria-label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
-        className={styles.expandButton}
-        onClick={() => setIsExpanded((prev) => !prev)}
-        type='button'
+    <div className={styles.sidebarRail}>
+      <aside
+        data-testid={dataTestId}
+        className={clsx(
+          styles.sidebar,
+          isExpanded && styles.expanded,
+          extraClass
+        )}
       >
-        <span
-          className={clsx(
-            styles.expandIconWrapper,
-            isExpanded && styles.rotated
-          )}
+        <button
+          aria-label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
+          className={styles.expandButton}
+          onClick={() => setIsExpanded((prev) => !prev)}
+          type='button'
         >
-          <ChevronLeftIcon
-            color='white'
-            height={EXPAND_CHEVRON_HEIGHT}
-            width={EXPAND_CHEVRON_WIDTH}
-          />
-        </span>
-      </button>
-      <div className={styles.sidebarContent}>
-        {logo || logoCollapsed ? (
-          <div className={styles.headerSection}>
-            <div className={styles.topLogoWrapper}>
-              <div className={styles.logoCompact}>{logoCollapsed ?? logo}</div>
-              <div className={styles.logoFull}>{logo}</div>
+          <span
+            className={clsx(
+              styles.expandIconWrapper,
+              isExpanded && styles.rotated
+            )}
+          >
+            <ChevronLeftIcon
+              color='white'
+              height={EXPAND_CHEVRON_HEIGHT}
+              width={EXPAND_CHEVRON_WIDTH}
+            />
+          </span>
+        </button>
+        <div className={styles.sidebarContent}>
+          {logo || logoCollapsed ? (
+            <div className={styles.headerSection}>
+              <div className={styles.topLogoWrapper}>
+                <div className={styles.logoCompact}>
+                  {logoCollapsed ?? logo}
+                </div>
+                <div className={styles.logoFull}>{logo}</div>
+              </div>
             </div>
-          </div>
-        ) : null}
-        <nav className={styles.nav}>
-          <ul>{items.map(renderItem)}</ul>
-        </nav>
-        {footerItems?.length ? (
-          <div className={styles.bottomSection}>
-            <div className={styles.bottomNav}>
-              <ul>{footerItems.map(renderItem)}</ul>
+          ) : null}
+          <nav className={styles.nav}>
+            <ul>{items.map(renderItem)}</ul>
+          </nav>
+          {footerItems?.length ? (
+            <div className={styles.bottomSection}>
+              <div className={styles.bottomNav}>
+                <ul>{footerItems.map(renderItem)}</ul>
+              </div>
             </div>
-          </div>
-        ) : null}
-      </div>
-    </aside>
+          ) : null}
+        </div>
+      </aside>
+    </div>
   )
 }

--- a/lib/v2/components/Sidebar/sidebar.module.scss
+++ b/lib/v2/components/Sidebar/sidebar.module.scss
@@ -5,19 +5,32 @@
   box-sizing: border-box;
 }
 
-.sidebar {
-  z-index: 20;
-  display: flex;
-  height: 100vh;
-  flex-direction: column;
+/*
+ * The rail keeps a constant 64px footprint in normal flow so expanding the
+ * sidebar never reflows sibling content (e.g. dashboard charts). The panel
+ * itself is taken out of flow and overlays the content when expanded.
+ */
+.sidebarRail {
+  position: relative;
   flex-shrink: 0;
   width: 64px;
-  position: relative;
+  height: 100vh;
+  z-index: 20;
+}
+
+.sidebar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 20;
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  width: 64px;
   overflow: visible;
   font-family: var(--body-font, 'IBM Plex Sans', 'Exo 2', 'Roboto', sans-serif);
   color: $gray-0;
   background: linear-gradient(0deg, #0f051a 13.47%, #4b2370 88.95%);
-  backdrop-filter: blur(10px);
   border-right: 1px solid rgb(255 255 255 / 10%);
   transition: width 500ms cubic-bezier(0.4, 0, 0.2, 1);
   will-change: width;


### PR DESCRIPTION
## Problem
Expanding/collapsing the sidebar animates its `width`. Because the sidebar sits in normal flow as a flex sibling of the page content, **every animation frame reflows the entire content area**. On heavy pages (dashboards with many charts) this causes visible lag for the whole 500ms animation and a stuttery logo crossfade. Consumer-side mitigations (debouncing chart `ResizeObserver`s) help but can't remove the per-frame reflow itself.

## Fix
Decouple the sidebar from the content flow:
- A **rail** (`.sidebarRail`) stays in flow with a constant **64px** footprint — sibling content keeps a fixed width and never reflows.
- The **panel** (`.sidebar`) becomes `position: absolute` and animates its width as an **overlay**.
- Dropped `backdrop-filter: blur(10px)` — invisible over the opaque gradient background, but expensive to recompute each frame (and more so now that the panel overlays content).

Result: opening/closing the sidebar no longer reflows or repaints sibling content, so dashboards stay smooth and the logo crossfade is fluid.

## Trade-off
The expanded panel now **overlays** the left edge of the content instead of pushing it. This is the intended change — it's what allows zero content reflow.

## Compatibility
- No API change. `extraClass` and `data-testid` remain on the panel (`<aside>`).
- All 29 Sidebar tests pass; diff-lint, prettier, and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)