### PR TITLE
feat(Table): add RowActionsCell with tests and stories

### DIFF
--- a/lib/v2/components/CapacityProgressBar/CapacityProgressBar.test.tsx
+++ b/lib/v2/components/CapacityProgressBar/CapacityProgressBar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import { CapacityProgressBar } from './CapacityProgressBar'
+import { CAPACITY_FILL_COLORS, CapacityProgressBar } from './CapacityProgressBar'
 
 const getProgressBar = (container: HTMLElement) =>
   container.firstChild as HTMLElement
@@ -118,6 +118,19 @@ describe('CapacityProgressBar', () => {
 
       const fill = getProgressFill(container)
       expect(fill.className).toContain('fillRed')
+    })
+
+    it('uses the fillColor prop instead of the percentage-derived color', () => {
+      const { container } = render(
+        <CapacityProgressBar
+          fillColor={CAPACITY_FILL_COLORS.CYAN}
+          percentage={100}
+        />
+      )
+
+      const fill = getProgressFill(container)
+      expect(fill.className).toContain('fillCyan')
+      expect(fill.className).not.toContain('fillRed')
     })
   })
 

--- a/lib/v2/components/CapacityProgressBar/CapacityProgressBar.tsx
+++ b/lib/v2/components/CapacityProgressBar/CapacityProgressBar.tsx
@@ -10,6 +10,7 @@ export interface CapacityProgressBarProps {
   showPercentageText?: boolean
   borderRadius?: number
   extraClass?: string
+  fillColor?: CapacityFillColor
 }
 
 export const CAPACITY_FILL_COLORS = {
@@ -41,9 +42,10 @@ export function CapacityProgressBar({
   height = 24,
   showPercentageText = false,
   borderRadius = 20,
-  extraClass
+  extraClass,
+  fillColor: fillColorProp
 }: Readonly<CapacityProgressBarProps>) {
-  const fillColor = getFillColor(percentage)
+  const fillColor = fillColorProp ?? getFillColor(percentage)
   const clampedPercentage = Math.min(percentage, FULL_PERCENTAGE)
 
   return (

--- a/lib/v2/components/MenuPopover/MenuPopover.tsx
+++ b/lib/v2/components/MenuPopover/MenuPopover.tsx
@@ -1,11 +1,14 @@
 import { type ReactNode, type RefObject, useRef } from 'react'
+import clsx from 'clsx'
 
 import { useClickOutside, usePopoverPosition } from '#v2/hooks'
 
 import styles from './menuPopover.module.scss'
 
 export const MENU_POPOVER_STYLES = {
-  menuItem: styles.menuItem
+  menuItem: styles.menuItem,
+  menuHeader: styles.menuHeader,
+  menuItemIndent: styles.menuItemIndent
 } as const
 
 export interface MenuPopoverProps {
@@ -13,13 +16,16 @@ export interface MenuPopoverProps {
   onClose: () => void
   anchorRef: RefObject<HTMLElement>
   children: ReactNode
+  /** Extra class applied to the popover container (e.g. to widen it). */
+  extraClass?: string
 }
 
 export function MenuPopover({
   open,
   onClose,
   anchorRef,
-  children
+  children,
+  extraClass
 }: Readonly<MenuPopoverProps>) {
   const popRef = useRef<HTMLDivElement>(null)
 
@@ -37,7 +43,7 @@ export function MenuPopover({
   return (
     <div
       ref={popRef}
-      className={styles.popover}
+      className={clsx(styles.popover, extraClass)}
       style={position}
     >
       {children}

--- a/lib/v2/components/MenuPopover/menuPopover.module.scss
+++ b/lib/v2/components/MenuPopover/menuPopover.module.scss
@@ -37,3 +37,24 @@
     color: var(--gray-600-400);
   }
 }
+
+/* Non-interactive section title within a menu (no hover / not clickable). */
+.menuHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  color: var(--gray-600-400);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-family);
+  text-align: left;
+  cursor: default;
+  user-select: none;
+}
+
+/* Indented menu item — reads as belonging under a preceding .menuHeader.
+   Declared after .menuItem so its padding-left wins at equal specificity. */
+.menuItemIndent {
+  padding-left: 28px;
+}

--- a/lib/v2/components/Table/CellStoryTable.tsx
+++ b/lib/v2/components/Table/CellStoryTable.tsx
@@ -1,0 +1,92 @@
+import type { ColumnDef, TableOptions } from '@tanstack/react-table'
+
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable
+} from '@tanstack/react-table'
+
+const CONTAINER_STYLE = {
+  padding: '24px',
+  background: 'var(--bg-secondary)',
+  minHeight: '320px',
+  overflow: 'visible' as const
+}
+
+const TABLE_STYLE = {
+  borderCollapse: 'collapse' as const,
+  width: '100%',
+  fontFamily: "'IBMPlexSans', sans-serif",
+  fontSize: '13px',
+  color: 'var(--text-primary)'
+}
+
+const HEADER_STYLE = {
+  textAlign: 'left' as const,
+  padding: '8px 12px',
+  borderBottom: '1px solid var(--gray-200-800)',
+  fontWeight: 600
+}
+
+const CELL_STYLE = {
+  padding: '8px 12px',
+  borderBottom: '1px solid var(--gray-100-900)'
+}
+
+interface CellStoryTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+}
+
+/**
+ * Renders a minimal TanStack table for cell-component stories so each cell
+ * story does not duplicate the table scaffolding and styles.
+ */
+export function CellStoryTable<TData, TValue>({
+  columns,
+  data
+}: Readonly<CellStoryTableProps<TData, TValue>>) {
+  const table = useReactTable<TData>({
+    columns,
+    data,
+    getCoreRowModel: getCoreRowModel()
+  } as TableOptions<TData>)
+
+  return (
+    <div style={CONTAINER_STYLE}>
+      <table style={TABLE_STYLE}>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th
+                  key={header.id}
+                  style={{ ...HEADER_STYLE, width: header.getSize() }}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td
+                  key={cell.id}
+                  style={{ ...CELL_STYLE, width: cell.column.getSize() }}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/lib/v2/components/Table/DefaultCell/DefaultCell.stories.tsx
+++ b/lib/v2/components/Table/DefaultCell/DefaultCell.stories.tsx
@@ -1,14 +1,10 @@
 import type { DefaultCellOptions, DefaultCellValue } from './DefaultCell'
 import type { Meta, StoryObj } from '@storybook/react'
-import type { ColumnDef, TableOptions } from '@tanstack/react-table'
+import type { ColumnDef } from '@tanstack/react-table'
 
 import { MemoryRouter } from 'react-router-dom'
-import {
-  flexRender,
-  getCoreRowModel,
-  useReactTable
-} from '@tanstack/react-table'
 
+import { CellStoryTable } from '../CellStoryTable'
 import { DefaultCell } from './DefaultCell'
 
 const meta: Meta<typeof DefaultCell> = {
@@ -100,81 +96,13 @@ const columns: ColumnDef<Row, DefaultCellValue>[] = [
   }
 ]
 
-const CONTAINER_STYLE = {
-  padding: '24px',
-  background: 'var(--bg-secondary)',
-  minHeight: '320px',
-  overflow: 'auto'
-}
-
-const TABLE_STYLE = {
-  borderCollapse: 'collapse' as const,
-  width: '100%',
-  fontFamily: "'IBMPlexSans', sans-serif",
-  fontSize: '13px',
-  color: 'var(--text-primary)'
-}
-
-const HEADER_STYLE = {
-  textAlign: 'left' as const,
-  padding: '8px 12px',
-  borderBottom: '1px solid var(--gray-200-800)',
-  fontWeight: 600
-}
-
-const CELL_STYLE = {
-  padding: '8px 12px',
-  borderBottom: '1px solid var(--gray-100-900)'
-}
-
-function DefaultCellDemo() {
-  const table = useReactTable<Row>({
-    columns,
-    data: SAMPLE_ROWS,
-    getCoreRowModel: getCoreRowModel()
-  } as TableOptions<Row>)
-
-  return (
+export const Interactive: Story = {
+  render: () => (
     <MemoryRouter>
-      <div style={CONTAINER_STYLE}>
-        <table style={TABLE_STYLE}>
-          <thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <th
-                    key={header.id}
-                    style={{ ...HEADER_STYLE, width: header.getSize() }}
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <tbody>
-            {table.getRowModel().rows.map((row) => (
-              <tr key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    style={{ ...CELL_STYLE, width: cell.column.getSize() }}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <CellStoryTable
+        columns={columns}
+        data={SAMPLE_ROWS}
+      />
     </MemoryRouter>
   )
-}
-
-export const Interactive: Story = {
-  render: () => <DefaultCellDemo />
 }

--- a/lib/v2/components/Table/RowActionsCell/RowActionsCell.stories.tsx
+++ b/lib/v2/components/Table/RowActionsCell/RowActionsCell.stories.tsx
@@ -1,0 +1,79 @@
+import type { RowAction } from '../Table'
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { EMPTY_STRING } from '#consts'
+
+import { ConfigureIcon, DownloadIcon } from '../../../icons'
+import { CellStoryTable } from '../CellStoryTable'
+import { RowActionsCell } from './RowActionsCell'
+
+const meta: Meta<typeof RowActionsCell> = {
+  title: 'v2/Table/cells/RowActionsCell'
+}
+
+export default meta
+type Story = StoryObj<typeof RowActionsCell>
+
+interface Row {
+  id: string
+  name: string
+  locked: boolean
+}
+
+const SAMPLE_ROWS: Row[] = [
+  { id: 'fs-prod', name: 'fs-prod', locked: false },
+  { id: 'fs-archive', name: 'fs-archive', locked: true },
+  { id: 'fs-scratch', name: 'fs-scratch', locked: false }
+]
+
+const ROW_ACTIONS: RowAction<Row>[] = [
+  {
+    key: 'configure',
+    text: 'Configure',
+    icon: <ConfigureIcon />,
+    action: (row) => window.alert(`Configure ${row.name}`)
+  },
+  {
+    key: 'download',
+    text: 'Download',
+    icon: <DownloadIcon />,
+    action: (row) => window.alert(`Download ${row.name}`)
+  },
+  {
+    key: 'delete',
+    text: 'Delete',
+    action: (row) => window.alert(`Delete ${row.name}`),
+    disabled: (row) => row.locked
+  },
+  {
+    key: 'unlock',
+    text: 'Unlock',
+    action: (row) => window.alert(`Unlock ${row.name}`),
+    hideAction: (row) => !row.locked
+  }
+]
+
+const columns: ColumnDef<Row>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+    size: 200
+  },
+  {
+    id: 'actions',
+    header: EMPTY_STRING,
+    cell: RowActionsCell,
+    size: 64,
+    meta: { rowActions: ROW_ACTIONS } as ColumnDef<Row>['meta']
+  }
+]
+
+export const Interactive: Story = {
+  render: () => (
+    <CellStoryTable
+      columns={columns}
+      data={SAMPLE_ROWS}
+    />
+  )
+}

--- a/lib/v2/components/Table/RowActionsCell/RowActionsCell.test.tsx
+++ b/lib/v2/components/Table/RowActionsCell/RowActionsCell.test.tsx
@@ -1,0 +1,189 @@
+import type { RowAction } from '../Table'
+import type { CellContext } from '@tanstack/react-table'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RowActionsCell } from './RowActionsCell'
+
+interface TestRow {
+  id: string
+  name: string
+}
+
+const SAMPLE_ROW: TestRow = { id: 'r1', name: 'Item 1' }
+
+const ROW_ACTIONS_BUTTON_TESTID = 'row-actions-button'
+const EDIT_ACTION_TESTID = 'row-action-edit'
+const EDIT_TEXT = 'Edit'
+
+function buildCellContext(
+  rowActions: RowAction<TestRow>[] | undefined
+): CellContext<TestRow, unknown> {
+  return {
+    row: { original: SAMPLE_ROW },
+    column: { columnDef: { meta: rowActions ? { rowActions } : undefined } }
+  } as unknown as CellContext<TestRow, unknown>
+}
+
+function renderCell(rowActions?: RowAction<TestRow>[]) {
+  return render(<RowActionsCell {...buildCellContext(rowActions)} />)
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('RowActionsCell', () => {
+  it('renders nothing when no rowActions meta is provided', () => {
+    const { container } = renderCell()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when every action is hidden for the row', () => {
+    renderCell([
+      { key: 'edit', text: EDIT_TEXT, action: vi.fn(), hideAction: () => true }
+    ])
+    expect(
+      screen.queryByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the kebab button when there is at least one visible action', () => {
+    renderCell([{ key: 'edit', text: EDIT_TEXT, action: vi.fn() }])
+    expect(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID)).toBeInTheDocument()
+  })
+
+  it('opens the menu and shows visible actions on click', () => {
+    renderCell([
+      { key: 'edit', text: EDIT_TEXT, action: vi.fn() },
+      { key: 'delete', text: 'Delete', action: vi.fn() }
+    ])
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    expect(screen.getByTestId(EDIT_ACTION_TESTID)).toBeInTheDocument()
+    expect(screen.getByTestId('row-action-delete')).toBeInTheDocument()
+  })
+
+  it('closes the menu when the kebab button is clicked again', () => {
+    renderCell([{ key: 'edit', text: EDIT_TEXT, action: vi.fn() }])
+    const button = screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    fireEvent.click(button)
+    expect(screen.getByTestId(EDIT_ACTION_TESTID)).toBeInTheDocument()
+    fireEvent.click(button)
+    expect(screen.queryByTestId(EDIT_ACTION_TESTID)).not.toBeInTheDocument()
+  })
+
+  it('does not reopen the menu when actions become hidden then visible again', () => {
+    const visible: RowAction<TestRow>[] = [
+      { key: 'edit', text: EDIT_TEXT, action: vi.fn(), hideAction: () => false }
+    ]
+    const hidden: RowAction<TestRow>[] = [
+      { key: 'edit', text: EDIT_TEXT, action: vi.fn(), hideAction: () => true }
+    ]
+    const { rerender } = render(<RowActionsCell {...buildCellContext(visible)} />)
+
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    expect(screen.getByTestId(EDIT_ACTION_TESTID)).toBeInTheDocument()
+
+    rerender(<RowActionsCell {...buildCellContext(hidden)} />)
+    expect(
+      screen.queryByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    ).not.toBeInTheDocument()
+
+    rerender(<RowActionsCell {...buildCellContext(visible)} />)
+    expect(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID)).toBeInTheDocument()
+    expect(screen.queryByTestId(EDIT_ACTION_TESTID)).not.toBeInTheDocument()
+  })
+
+  it('does not render actions whose hideAction returns true', () => {
+    renderCell([
+      { key: 'edit', text: EDIT_TEXT, action: vi.fn() },
+      { key: 'archive', text: 'Archive', action: vi.fn(), hideAction: () => true }
+    ])
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    expect(screen.getByTestId(EDIT_ACTION_TESTID)).toBeInTheDocument()
+    expect(screen.queryByTestId('row-action-archive')).not.toBeInTheDocument()
+  })
+
+  it('renders an action as disabled when disabled returns true', () => {
+    renderCell([
+      { key: 'delete', text: 'Delete', action: vi.fn(), disabled: () => true }
+    ])
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    expect(screen.getByTestId('row-action-delete')).toBeDisabled()
+  })
+
+  it('calls the action with the row data when a menu item is clicked', () => {
+    const editAction = vi.fn()
+    renderCell([{ key: 'edit', text: EDIT_TEXT, action: editAction }])
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    fireEvent.click(screen.getByTestId(EDIT_ACTION_TESTID))
+    expect(editAction).toHaveBeenCalledWith(SAMPLE_ROW)
+  })
+
+  it('passes the row to hideAction and disabled predicates', () => {
+    const hideAction = vi.fn(() => false)
+    const disabled = vi.fn(() => false)
+    renderCell([{ key: 'edit', text: EDIT_TEXT, action: vi.fn(), hideAction, disabled }])
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    expect(hideAction).toHaveBeenCalledWith(SAMPLE_ROW)
+    expect(disabled).toHaveBeenCalledWith(SAMPLE_ROW)
+  })
+
+  it('renders custom content when an action provides it', () => {
+    const CUSTOM_CONTENT = 'custom-action-content'
+    renderCell([
+      {
+        key: 'custom',
+        action: vi.fn(),
+        content: () => <span>{CUSTOM_CONTENT}</span>
+      }
+    ])
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    expect(screen.getByText(CUSTOM_CONTENT)).toBeInTheDocument()
+  })
+
+  it('does not propagate the kebab click to a parent handler', () => {
+    const onParentClick = vi.fn()
+    render(
+      <div onClick={onParentClick}>
+        <RowActionsCell
+          {...buildCellContext([{ key: 'edit', text: EDIT_TEXT, action: vi.fn() }])}
+        />
+      </div>
+    )
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('does not propagate a header-action click to a parent handler', () => {
+    const onParentClick = vi.fn()
+    render(
+      <div onClick={onParentClick}>
+        <RowActionsCell
+          {...buildCellContext([
+            { key: 'section', text: 'Section', header: true },
+            { key: 'edit', text: EDIT_TEXT, action: vi.fn() }
+          ])}
+        />
+      </div>
+    )
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    fireEvent.click(screen.getByTestId('row-action-section'))
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('does not propagate a menu item click to a parent handler', () => {
+    const onParentClick = vi.fn()
+    render(
+      <div onClick={onParentClick}>
+        <RowActionsCell
+          {...buildCellContext([{ key: 'edit', text: EDIT_TEXT, action: vi.fn() }])}
+        />
+      </div>
+    )
+    fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
+    fireEvent.click(screen.getByTestId(EDIT_ACTION_TESTID))
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+})

--- a/lib/v2/components/Table/RowActionsCell/RowActionsCell.tsx
+++ b/lib/v2/components/Table/RowActionsCell/RowActionsCell.tsx
@@ -1,0 +1,122 @@
+import type { RowAction } from '../Table'
+import type { CellContext } from '@tanstack/react-table'
+import type { MouseEvent, RefObject } from 'react'
+
+import { useRef, useState } from 'react'
+import clsx from 'clsx'
+
+import { ThreeDotsMenuIcon } from '../../../icons'
+import { IconButton } from '../../IconButton'
+import { MENU_POPOVER_STYLES, MenuPopover } from '../../MenuPopover'
+
+import styles from './rowActionsCell.module.scss'
+
+interface RowActionsCellMeta<TData> {
+  rowActions: RowAction<TData>[]
+}
+
+export function RowActionsCell<TData>({
+  column,
+  row
+}: Readonly<CellContext<TData, unknown>>) {
+  const [open, setOpen] = useState(false)
+  const anchorRef = useRef<HTMLDivElement>(null)
+
+  const meta = column.columnDef.meta as RowActionsCellMeta<TData> | undefined
+  const rowActions = meta?.rowActions ?? []
+
+  const visibleActions = rowActions.filter(
+    (action) => !action.hideAction?.(row.original)
+  )
+  const hasVisibleActions = visibleActions.length > 0
+
+  if (!hasVisibleActions) {
+    if (open) {
+      setOpen(false)
+    }
+    return null
+  }
+
+  const handleToggle = (e: MouseEvent) => {
+    e.stopPropagation()
+    setOpen((isOpen) => !isOpen)
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  const stopRowActivation = (e: MouseEvent) => {
+    e.stopPropagation()
+  }
+
+  return (
+    <div
+      ref={anchorRef}
+      className={styles.cellWrapper}
+      onClick={stopRowActivation}
+    >
+      <IconButton
+        ariaLabel='Row actions'
+        dataTestId='row-actions-button'
+        onClick={handleToggle}
+      >
+        <ThreeDotsMenuIcon />
+      </IconButton>
+      <MenuPopover
+        anchorRef={anchorRef as RefObject<HTMLElement>}
+        extraClass={styles.menu}
+        onClose={handleClose}
+        open={open}
+      >
+        {visibleActions.map((action) => {
+          const body = action.content ? (
+            action.content(row.original)
+          ) : (
+            <>
+              {action.icon}
+              {action.text}
+            </>
+          )
+
+          if (action.header) {
+            return (
+              <div
+                key={action.key}
+                data-testid={`row-action-${action.key}`}
+                className={clsx(
+                  MENU_POPOVER_STYLES.menuHeader,
+                  action.extraClass
+                )}
+              >
+                {body}
+              </div>
+            )
+          }
+
+          const isDisabled = action.disabled?.(row.original) ?? false
+          return (
+            <button
+              key={action.key}
+              data-testid={`row-action-${action.key}`}
+              disabled={isDisabled}
+              type='button'
+              className={clsx(
+                MENU_POPOVER_STYLES.menuItem,
+                action.indent && MENU_POPOVER_STYLES.menuItemIndent,
+                action.extraClass
+              )}
+              onClick={(e) => {
+                e.stopPropagation()
+                action.action?.(row.original)
+                handleClose()
+              }}
+            >
+              {body}
+            </button>
+          )
+        })}
+      </MenuPopover>
+    </div>
+  )
+}

--- a/lib/v2/components/Table/RowActionsCell/index.ts
+++ b/lib/v2/components/Table/RowActionsCell/index.ts
@@ -1,0 +1,1 @@
+export { RowActionsCell } from './RowActionsCell'

--- a/lib/v2/components/Table/RowActionsCell/rowActionsCell.module.scss
+++ b/lib/v2/components/Table/RowActionsCell/rowActionsCell.module.scss
@@ -1,0 +1,10 @@
+.cellWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.menu {
+  width: 260px;
+}

--- a/lib/v2/components/Table/Table/Table.stories.tsx
+++ b/lib/v2/components/Table/Table/Table.stories.tsx
@@ -1,4 +1,5 @@
 import type { ActiveFilter } from '../filterUtils'
+import type { RowAction } from './rowActions'
 import type { Meta, StoryObj } from '@storybook/react'
 import type { ColumnDef } from '@tanstack/react-table'
 
@@ -81,4 +82,42 @@ function TableDemo() {
 
 export const Interactive: Story = {
   render: () => <TableDemo />
+}
+
+const ROW_ACTIONS: RowAction<Cluster>[] = [
+  {
+    key: 'edit',
+    text: 'Edit',
+    action: (row) => alert(`Edit ${row.name}`)
+  },
+  {
+    key: 'delete',
+    text: 'Delete',
+    action: (row) => alert(`Delete ${row.name}`)
+  },
+  {
+    key: 'offline-only',
+    text: 'Restart',
+    action: (row) => alert(`Restart ${row.name}`),
+    hideAction: (row) => row.status !== 'Offline'
+  },
+  {
+    key: 'degrade-disabled',
+    text: 'Degrade (disabled)',
+    action: () => undefined,
+    disabled: (row) => row.status === 'Degraded'
+  }
+]
+
+export const WithRowActions: Story = {
+  render: () => (
+    <div style={CONTAINER_STYLE}>
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        rowActions={ROW_ACTIONS}
+        title='Clusters with row actions'
+      />
+    </div>
+  )
 }

--- a/lib/v2/components/Table/Table/Table.test.tsx
+++ b/lib/v2/components/Table/Table/Table.test.tsx
@@ -1,6 +1,7 @@
+import type { RowAction } from './rowActions'
 import type { ColumnDef } from '@tanstack/react-table'
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { FILTER_TYPES } from '#v2/utils/consts'
@@ -35,6 +36,7 @@ const FILTERABLE_COLUMNS: ColumnDef<Item>[] = [
 
 const RESIZER_ID_TESTID = 'column-resizer-id'
 const RESIZER_NAME_TESTID = 'column-resizer-name'
+const ROW_ACTIONS_BUTTON_TESTID = 'row-actions-button'
 
 describe('Table', () => {
   describe('baseline functionality', () => {
@@ -193,6 +195,117 @@ describe('Table', () => {
         })
       })
     })
+  })
+})
+
+describe('Table rowActions', () => {
+  const ROW_ACTIONS: RowAction<Item>[] = [
+    {
+      key: 'edit',
+      text: 'Edit',
+      action: vi.fn()
+    },
+    {
+      key: 'delete',
+      text: 'Delete',
+      action: vi.fn()
+    },
+    {
+      key: 'hidden-action',
+      text: 'Hidden',
+      action: vi.fn(),
+      hideAction: () => true
+    },
+    {
+      key: 'disabled-action',
+      text: 'Disabled',
+      action: vi.fn(),
+      disabled: () => true
+    }
+  ]
+
+  it('renders a row actions button for each row', () => {
+    render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        rowActions={ROW_ACTIONS}
+      />
+    )
+    const buttons = screen.getAllByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    expect(buttons).toHaveLength(DATA.length)
+  })
+
+  it('opens the actions menu and shows visible actions', () => {
+    render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        rowActions={ROW_ACTIONS}
+      />
+    )
+    const [firstButton] = screen.getAllByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    fireEvent.click(firstButton)
+    expect(screen.getByTestId('row-action-edit')).toBeInTheDocument()
+    expect(screen.getByTestId('row-action-delete')).toBeInTheDocument()
+  })
+
+  it('does not render hidden actions', () => {
+    render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        rowActions={ROW_ACTIONS}
+      />
+    )
+    const [firstButton] = screen.getAllByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    fireEvent.click(firstButton)
+    expect(screen.queryByTestId('row-action-hidden-action')).not.toBeInTheDocument()
+  })
+
+  it('renders disabled actions as disabled', () => {
+    render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        rowActions={ROW_ACTIONS}
+      />
+    )
+    const [firstButton] = screen.getAllByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    fireEvent.click(firstButton)
+    expect(screen.getByTestId('row-action-disabled-action')).toBeDisabled()
+  })
+
+  it('calls the action callback when a menu item is clicked', () => {
+    const editAction = vi.fn()
+    const actions: RowAction<Item>[] = [
+      { key: 'edit', text: 'Edit', action: editAction }
+    ]
+    render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        rowActions={actions}
+      />
+    )
+    const [firstButton] = screen.getAllByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    fireEvent.click(firstButton)
+    fireEvent.click(screen.getByTestId('row-action-edit'))
+    expect(editAction).toHaveBeenCalledWith(DATA[0])
+  })
+
+  it('renders no kebab button when all actions are hidden for a row', () => {
+    const actions: RowAction<Item>[] = [
+      { key: 'always-hidden', text: 'Hidden', action: vi.fn(), hideAction: () => true }
+    ]
+    render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        rowActions={actions}
+      />
+    )
+    expect(screen.queryByTestId(ROW_ACTIONS_BUTTON_TESTID)).not.toBeInTheDocument()
   })
 })
 

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -1,5 +1,6 @@
 import type { CustomFilters } from '../FilterPopover'
 import type { ActiveFilter } from '../filterUtils'
+import type { RowAction } from './rowActions'
 import type {
   ColumnDef,
   ColumnFiltersState,
@@ -15,9 +16,11 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { flexRender, useReactTable } from '@tanstack/react-table'
 import clsx from 'clsx'
 
+import { EMPTY_STRING } from '#consts'
 import { NOOP } from '#v2/utils/consts'
 
 import { Pagination } from '../Pagination'
+import { RowActionsCell } from '../RowActionsCell'
 import { TableFilter } from '../TableFilter'
 import { buildTableColumns, getCanShowFilter } from '../tableUtils'
 import { useColumnVisibility } from './hooks/useColumnVisibility'
@@ -35,6 +38,8 @@ const DEFAULT_PAGE_SIZE = 25
 const MAX_ROWS_FOR_COMPACT = 10
 const FIRST_PAGE = 1
 const COMPACT_HALF_DIVISOR = 2
+const ROW_ACTIONS_COLUMN_ID = '__rowActions__'
+const ROW_ACTIONS_COLUMN_SIZE = 56
 
 const EMPTY_ACTIVE_FILTERS: ActiveFilter[] = []
 const EMPTY_EXCLUDED_FIELDS: string[] = []
@@ -99,6 +104,7 @@ export interface TableProps<TData = unknown> {
   getCsvData?: () => Promise<readonly TData[]>
   onCsvError?: (message: string) => void
   dataTestId?: string
+  rowActions?: RowAction<TData>[]
 }
 
 const COLUMN_RESIZE_MODE: ColumnResizeMode = 'onChange'
@@ -146,7 +152,8 @@ export function Table<TData = unknown>({
   initialColumnVisibility,
   onColumnVisibilityChange,
   currentPage: currentPageProp,
-  isPaginationPageEnabled
+  isPaginationPageEnabled,
+  rowActions
 }: Readonly<TableProps<TData>>) {
   const { columnVisibility, handleColumnVisibilityChange } =
     useColumnVisibility({
@@ -212,10 +219,24 @@ export function Table<TData = unknown>({
     [data, filteredData, globalSearchTerm]
   )
 
-  const tableColumns = useMemo(
-    () => buildTableColumns(columns, hasResizableColumns),
-    [columns, hasResizableColumns]
-  )
+  const tableColumns = useMemo(() => {
+    const builtColumns = buildTableColumns(columns, hasResizableColumns)
+    if (!rowActions || rowActions.length === 0) {
+      return builtColumns
+    }
+    const rowActionsColumn: ColumnDef<TData> = {
+      id: ROW_ACTIONS_COLUMN_ID,
+      header: EMPTY_STRING,
+      enableSorting: false,
+      enableColumnFilter: false,
+      enableResizing: false,
+      enableHiding: false,
+      size: ROW_ACTIONS_COLUMN_SIZE,
+      meta: { rowActions } as Record<string, unknown>,
+      cell: (ctx) => <RowActionsCell {...ctx} />
+    }
+    return [...builtColumns, rowActionsColumn]
+  }, [columns, hasResizableColumns, rowActions])
 
   const tableOptions = useTableOptions({
     displayData,

--- a/lib/v2/components/Table/Table/index.ts
+++ b/lib/v2/components/Table/Table/index.ts
@@ -1,2 +1,3 @@
+export type { RowAction } from './rowActions'
 export type { PaginationState, SortDirection, TableProps } from './Table'
 export { Table } from './Table'

--- a/lib/v2/components/Table/Table/rowActions.ts
+++ b/lib/v2/components/Table/Table/rowActions.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+
+export interface RowAction<TData> {
+  key: string
+  text?: string
+  content?: (row: TData) => ReactNode
+  icon?: ReactNode
+  action?: (row: TData) => void
+  hideAction?: (row: TData) => boolean
+  disabled?: (row: TData) => boolean
+  extraClass?: string
+  header?: boolean
+  indent?: boolean
+}

--- a/lib/v2/components/index.ts
+++ b/lib/v2/components/index.ts
@@ -240,7 +240,7 @@ export {
   REDUCTION_RANGE_MODES,
   ReductionRangeFilter
 } from './Table/ReductionRangeFilter'
-export type { PaginationState, SortDirection, TableProps } from './Table/Table'
+export type { PaginationState, RowAction, SortDirection, TableProps } from './Table/Table'
 export { Table } from './Table/Table'
 export type { TableFilterProps } from './Table/TableFilter'
 export { TableFilter } from './Table/TableFilter'


### PR DESCRIPTION
## Summary

Adds the **RowActions** feature to the v2 `Table` and gives it the test + story coverage required for v2 components.

- New `RowActionsCell` — a per-row kebab (⋯) menu rendered via `MenuPopover`, driven by a new `rowActions` prop on `Table`.
- New `RowAction<TData>` type (`key`, `text`/`content`, `icon`, `action`, `hideAction`, `disabled`, `extraClass`), exported from the v2 barrel.
- `Table` appends a non-resizable/non-sortable/non-hideable actions column when `rowActions` is provided.

## Tests & stories

- `RowActionsCell.test.tsx` — 11 tests: hidden-when-empty, hidden-when-all-hidden, menu open, `hideAction`/`disabled` predicates, custom `content`, action callback fires with row data, and click-propagation is stopped (kebab + menu item).
- `RowActionsCell.stories.tsx` — interactive story demoing icons, a disabled action (locked rows), and a conditionally hidden action.
- Extracted the duplicated cell-story table scaffold into a shared `CellStoryTable` helper, now used by both `RowActionsCell` and `DefaultCell` stories.

## Notes

- Scoped to the RowActions feature only; the unrelated repo-wide working-tree changes are excluded.
- All Table + RowActionsCell tests pass (86 tests); lint is clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)