### PR TITLE
style(HealthStatus): left-align content and restyle progress bar

### DIFF
--- a/lib/v2/components/HealthStatus/healthStatus.module.scss
+++ b/lib/v2/components/HealthStatus/healthStatus.module.scss
@@ -20,10 +20,10 @@
 .content {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  gap: 4px;
-  text-align: center;
+  gap: 2px;
+  text-align: left;
 }
 
 .text {
@@ -36,17 +36,17 @@
 .progressWrapper {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
 }
 
 .progressContainer {
   position: relative;
-  flex-grow: 1;
-  min-width: 80px;
+  width: 133px;
   max-width: 100%;
-  height: 8px;
+  height: 10px;
   background-color: var(--orange-200-800);
-  border-radius: 4px;
+  border-radius: 20px;
+  flex-shrink: 0;
 }
 
 .progressBar {
@@ -55,7 +55,7 @@
   left: 0;
   height: 100%;
   background-color: var(--orange-500);
-  border-radius: 4px;
+  border-radius: 20px 0 0 20px;
   transition: width 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary

Visual/layout refinements to the `HealthStatus` component's styles:

- Left-align the content (status text) instead of centering — `align-items: flex-start`, `text-align: left`, tighter `gap` (4px → 2px).
- Tighten the progress wrapper gap (8px → 4px).
- Restyle the progress track/bar: fixed `133px` width (was flex-grow + 80px min), taller `10px` height (was 8px), pill `border-radius: 20px` with a rounded left cap on the fill, and `flex-shrink: 0`.

CSS-only change; no component/API changes.

## Notes

- Branched from latest `origin/main` (where `HealthStatus` lives) — not added to the unrelated Select PR #419.
- HealthStatus tests pass (5); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)