### PR TITLE
chore: upgrade @mui/material to v6 + fix Table circular-import load crash

### DIFF
--- a/lib/components/Table/hooks/useUrlFilters.ts
+++ b/lib/components/Table/hooks/useUrlFilters.ts
@@ -2,14 +2,13 @@ import type { ExtendedColumnFilter, UrlFilterParser } from '../types'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+
 import { SAVED_FILTERS } from '#consts'
 import { useStaticProps } from '#hooks'
+import Utils from '#utils'
 
 import localStorageService from '../../../localStorageService'
-import { Utils } from '../../../main'
 import { urlFilterParsers } from '../tableUtils'
-
-const defaultFilterParser = urlFilterParsers.string
 
 function useUrlFilters(props: {
   enabled?: boolean
@@ -49,7 +48,7 @@ function useUrlFilters(props: {
       const parsedSearchParams = Utils.parseSearchParamsToObject(searchParams)
 
       return filterConfig.flatMap(
-        ({ id, filterParser = defaultFilterParser }) => {
+        ({ id, filterParser = urlFilterParsers.string }) => {
           const filterParserFunc =
             typeof filterParser === 'string'
               ? urlFilterParsers[filterParser]

--- a/lib/components/Table/tableUtils.ts
+++ b/lib/components/Table/tableUtils.ts
@@ -1,11 +1,11 @@
 import type { ExtendedColumn, ExtendedRow, UrlFilterParser } from './types'
 import type { Severities } from '#consts'
 
-import { EMPTY_STRING, SEVERITIES } from '#consts'
 import { Duration } from 'luxon'
+
+import { EMPTY_STRING, SEVERITIES } from '#consts'
 import utils from '#utils'
 
-import { Utils } from '../../main'
 import {
   COMPARE_OPERATORS,
   type CompareOperator
@@ -299,7 +299,7 @@ export const urlFilterParsers = {
     Array.isArray(rawValue) ? rawValue : null,
   date: (rawValue: Parameters<UrlFilterParser>[0]) => {
     if (
-      !Utils.isObject(rawValue) ||
+      !utils.isObject(rawValue) ||
       (!rawValue?.startTime?.[0] && !rawValue?.endTime?.[0])
     ) {
       return null
@@ -316,7 +316,7 @@ export const urlFilterParsers = {
       : null,
   duration: (rawValue: Parameters<UrlFilterParser>[0]) => {
     if (
-      !Utils.isObject(rawValue) ||
+      !utils.isObject(rawValue) ||
       (!rawValue?.duration?.[0] && !rawValue?.operator?.[0])
     ) {
       return null
@@ -327,7 +327,7 @@ export const urlFilterParsers = {
     }
   },
   text: (rawValue: Parameters<UrlFilterParser>[0]) => {
-    if (Utils.isObject(rawValue) && rawValue?.pattern?.[0]) {
+    if (utils.isObject(rawValue) && rawValue?.pattern?.[0]) {
       const mode = rawValue?.mode?.[0]
       const validModes: TextFilterMode[] = [
         FILTER_MODES.INCLUDE,
@@ -347,7 +347,7 @@ export const urlFilterParsers = {
     return null
   },
   select: (rawValue: Parameters<UrlFilterParser>[0]) => {
-    if (Utils.isObject(rawValue) && rawValue?.value?.[0]) {
+    if (utils.isObject(rawValue) && rawValue?.value?.[0]) {
       const mode = rawValue?.mode?.[0]
       const validModes: SelectFilterMode[] = [
         FILTER_MODES.INCLUDE,
@@ -366,7 +366,7 @@ export const urlFilterParsers = {
     return null
   },
   multiSelect: (rawValue: Parameters<UrlFilterParser>[0]) => {
-    if (Utils.isObject(rawValue) && rawValue?.values) {
+    if (utils.isObject(rawValue) && rawValue?.values) {
       const mode = rawValue?.mode?.[0]
       const validModes: SelectFilterMode[] = [
         FILTER_MODES.INCLUDE,

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/material": "^5.11.1",
+    "@mui/material": "^5.11.1 || ^6.5.0",
     "luxon": "^3.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -112,7 +112,7 @@
     "@emotion/styled": "^11.14.1",
     "@eslint/compat": "^1.2.9",
     "@eslint/js": "^9.0.0",
-    "@mui/material": "^5.11.1",
+    "@mui/material": "^6.5.0",
     "@storybook/addon-actions": "^8.6.14",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-links": "^8.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,12 +2769,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
   version: 7.26.10
   resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: 10c0/6dc6d88c7908f505c4f7770fb4677dfa61f68f659b943c2be1f2a99cb6680343462867abf2d49822adc435932919b36c77ac60125793e719ea8745f2073d3745
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.26.0":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
   languageName: node
   linkType: hard
 
@@ -3129,7 +3136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.11.0, @emotion/cache@npm:^11.13.0, @emotion/cache@npm:^11.4.0":
+"@emotion/cache@npm:^11.13.0, @emotion/cache@npm:^11.4.0":
   version: 11.13.1
   resolution: "@emotion/cache@npm:11.13.1"
   dependencies:
@@ -3142,7 +3149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.14.0":
+"@emotion/cache@npm:^11.13.5, @emotion/cache@npm:^11.14.0":
   version: 11.14.0
   resolution: "@emotion/cache@npm:11.14.0"
   dependencies:
@@ -3893,101 +3900,106 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^5.16.7":
-  version: 5.16.7
-  resolution: "@mui/core-downloads-tracker@npm:5.16.7"
-  checksum: 10c0/4644c850160d01232c1abdbed141e4fa70e155891a9c68f0c2cc3054b4a3cdc1d28cf2d6665366fd8c725b2b091db677e11831552889a4e4e14f1e44450cf654
+"@mui/core-downloads-tracker@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@mui/core-downloads-tracker@npm:6.5.0"
+  checksum: 10c0/dea763c8d4b4f9415d6c6ac3a04115d04c249461ce5635f0012a75b91c38f43c0d0411201664a77c7ff10ff11ea12a0bfeea6562ec22ceec6bac82478b6384c3
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^5.11.1":
-  version: 5.16.7
-  resolution: "@mui/material@npm:5.16.7"
+"@mui/material@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@mui/material@npm:6.5.0"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/core-downloads-tracker": "npm:^5.16.7"
-    "@mui/system": "npm:^5.16.7"
-    "@mui/types": "npm:^7.2.15"
-    "@mui/utils": "npm:^5.16.6"
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/core-downloads-tracker": "npm:^6.5.0"
+    "@mui/system": "npm:^6.5.0"
+    "@mui/types": "npm:~7.2.24"
+    "@mui/utils": "npm:^6.4.9"
     "@popperjs/core": "npm:^2.11.8"
-    "@types/react-transition-group": "npm:^4.4.10"
-    clsx: "npm:^2.1.0"
+    "@types/react-transition-group": "npm:^4.4.12"
+    clsx: "npm:^2.1.1"
     csstype: "npm:^3.1.3"
     prop-types: "npm:^15.8.1"
-    react-is: "npm:^18.3.1"
+    react-is: "npm:^19.0.0"
     react-transition-group: "npm:^4.4.5"
   peerDependencies:
     "@emotion/react": ^11.5.0
     "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    "@mui/material-pigment-css": ^6.5.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@emotion/react":
       optional: true
     "@emotion/styled":
       optional: true
+    "@mui/material-pigment-css":
+      optional: true
     "@types/react":
       optional: true
-  checksum: 10c0/b11419c1a77835413471f9352586fed65fb5de19c6737e121669da0484c441c7dd9939aa73fdad779482c30efaa694fb9fdcf18dcf418af07881e60eaff92b4f
+  checksum: 10c0/24dfb582fe4655cc8e15476637d60d17cc1be6326be36d7fbc8c9a99f044ba10e5b68841f292e2cd1ce7e1ca26bc1006e37e7bba1e6979992850c907aa4c17b4
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^5.16.6":
-  version: 5.16.6
-  resolution: "@mui/private-theming@npm:5.16.6"
+"@mui/private-theming@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@mui/private-theming@npm:6.4.9"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/utils": "npm:^5.16.6"
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/utils": "npm:^6.4.9"
     prop-types: "npm:^15.8.1"
   peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/0a09afd6c2be37197973a856049f97e2f17f3e5e6cf6387af036055342efbfcd7d7066dcad587886f25f491e5940e4e9bb7d732d5099eb85b53b84ef120e9555
+  checksum: 10c0/3b198fad085b9ce5092cb2ad2aceee5f6a643f68f4fb1469d0748615490b8b9228179a6564be9c6784aa6f1f42a9afe61f1ad5ce0af56858e9bb58d36472e339
   languageName: node
   linkType: hard
 
-"@mui/styled-engine@npm:^5.16.6":
-  version: 5.16.6
-  resolution: "@mui/styled-engine@npm:5.16.6"
+"@mui/styled-engine@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@mui/styled-engine@npm:6.5.0"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@emotion/cache": "npm:^11.11.0"
+    "@babel/runtime": "npm:^7.26.0"
+    "@emotion/cache": "npm:^11.13.5"
+    "@emotion/serialize": "npm:^1.3.3"
+    "@emotion/sheet": "npm:^1.4.0"
     csstype: "npm:^3.1.3"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
-    react: ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@emotion/react":
       optional: true
     "@emotion/styled":
       optional: true
-  checksum: 10c0/b15e653c8756059c8ae2891ca54900573e22f6ed1aaf65a389ec838f2aca3252aeeb9a79aec4a43f080152b161a416e60b31a62595ba86ad5f72eda5642caaf2
+  checksum: 10c0/aa44806d2cdd1b65c756a97927edcd7907cc5649d206382b5b5b8c27f899552a002e713fb167aa0e5aa980542bd309166113830dc550672d7598ad5993e7ff66
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^5.16.7":
-  version: 5.16.7
-  resolution: "@mui/system@npm:5.16.7"
+"@mui/system@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@mui/system@npm:6.5.0"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/private-theming": "npm:^5.16.6"
-    "@mui/styled-engine": "npm:^5.16.6"
-    "@mui/types": "npm:^7.2.15"
-    "@mui/utils": "npm:^5.16.6"
-    clsx: "npm:^2.1.0"
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/private-theming": "npm:^6.4.9"
+    "@mui/styled-engine": "npm:^6.5.0"
+    "@mui/types": "npm:~7.2.24"
+    "@mui/utils": "npm:^6.4.9"
+    clsx: "npm:^2.1.1"
     csstype: "npm:^3.1.3"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     "@emotion/react": ^11.5.0
     "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@emotion/react":
       optional: true
@@ -3995,39 +4007,39 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10c0/c07479c0728433847c1e3d7f57b96d9e0770cc814dfd1c9e070304955984a0b706832703b22388eb83906d1a01691f37047e2bac6a5e5c083e8c29a54302d476
+  checksum: 10c0/2603ca8997625924e867504a53a20f81ad2dd7f3abb314709175341e4d2143bb22e2a9b4e8a008c92bf12e0333775dec651e8b9c237c4848650aabb60d8dab06
   languageName: node
   linkType: hard
 
-"@mui/types@npm:^7.2.15":
-  version: 7.2.19
-  resolution: "@mui/types@npm:7.2.19"
+"@mui/types@npm:~7.2.24":
+  version: 7.2.24
+  resolution: "@mui/types@npm:7.2.24"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/9c390d7eddc7e7c396852202fdca021aee275391bc7f48d0b6458748bf75eebb34c73109958692655ba5e72946cf47db2c0c7d2e1c26be568599ed65c931d080
+  checksum: 10c0/7756339cae70e9b684c4311924e4e3882f908552b69c434b4d13faf2f5908ce72fe889a31890257c5ad42a085207be7c1661981dfc683293e90ac6dfac3759d0
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^5.16.6":
-  version: 5.16.6
-  resolution: "@mui/utils@npm:5.16.6"
+"@mui/utils@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@mui/utils@npm:6.4.9"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/types": "npm:^7.2.15"
-    "@types/prop-types": "npm:^15.7.12"
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/types": "npm:~7.2.24"
+    "@types/prop-types": "npm:^15.7.14"
     clsx: "npm:^2.1.1"
     prop-types: "npm:^15.8.1"
-    react-is: "npm:^18.3.1"
+    react-is: "npm:^19.0.0"
   peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/2db3d11a83d7216fb8ceb459d4b30c795922c04cd8fabc26c721dd7b4f5ed5c4f3f3ace6ea70227bf3b79361bd58f13b723562cfd40255424d979ab238ab2e91
+  checksum: 10c0/27122262bc24d31e8906e3133f3f6e6c858733802019e0e9ec6dedf632ca46287ab3735c9da6be7a7e0b4f043ced9b8f36b5b21bfef1d96ecfa5d150ea458508
   languageName: node
   linkType: hard
 
@@ -5658,10 +5670,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*, @types/prop-types@npm:^15.7.12":
+"@types/prop-types@npm:*":
   version: 15.7.13
   resolution: "@types/prop-types@npm:15.7.13"
   checksum: 10c0/1b20fc67281902c6743379960247bc161f3f0406ffc0df8e7058745a85ea1538612109db0406290512947f9632fe9e10e7337bf0ce6338a91d6c948df16a7c61
+  languageName: node
+  linkType: hard
+
+"@types/prop-types@npm:^15.7.14":
+  version: 15.7.15
+  resolution: "@types/prop-types@npm:15.7.15"
+  checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
   languageName: node
   linkType: hard
 
@@ -5674,12 +5693,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-transition-group@npm:^4.4.0, @types/react-transition-group@npm:^4.4.10":
+"@types/react-transition-group@npm:^4.4.0":
   version: 4.4.11
   resolution: "@types/react-transition-group@npm:4.4.11"
   dependencies:
     "@types/react": "npm:*"
   checksum: 10c0/8fbf0dcc1b81985cdcebe3c59d769fe2ea3f4525f12c3a10a7429a59f93e303c82b2abb744d21cb762879f4514969d70a7ab11b9bf486f92213e8fe70e04098d
+  languageName: node
+  linkType: hard
+
+"@types/react-transition-group@npm:^4.4.12":
+  version: 4.4.12
+  resolution: "@types/react-transition-group@npm:4.4.12"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10c0/0441b8b47c69312c89ec0760ba477ba1a0808a10ceef8dc1c64b1013ed78517332c30f18681b0ec0b53542731f1ed015169fed1d127cc91222638ed955478ec7
   languageName: node
   linkType: hard
 
@@ -6471,7 +6499,7 @@ __metadata:
     "@emotion/styled": "npm:^11.14.1"
     "@eslint/compat": "npm:^1.2.9"
     "@eslint/js": "npm:^9.0.0"
-    "@mui/material": "npm:^5.11.1"
+    "@mui/material": "npm:^6.5.0"
     "@storybook/addon-actions": "npm:^8.6.14"
     "@storybook/addon-essentials": "npm:^8.6.14"
     "@storybook/addon-links": "npm:^8.6.14"
@@ -6547,7 +6575,7 @@ __metadata:
   peerDependencies:
     "@emotion/react": ^11.14.0
     "@emotion/styled": ^11.14.1
-    "@mui/material": ^5.11.1
+    "@mui/material": ^5.11.1 || ^6.5.0
     luxon: ^3.7.2
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -7723,7 +7751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^2.0.0, clsx@npm:^2.1.0, clsx@npm:^2.1.1":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
@@ -14040,6 +14068,13 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^19.0.0":
+  version: 19.2.7
+  resolution: "react-is@npm:19.2.7"
+  checksum: 10c0/419fe54d5bd7fdf5414a5bb7bd9a1e0e36f9fae28ffb4cb73290fbe342bde15d8584a90d1db62547f6aa03018dce517b178a041abb522136cd4b4b51b4e94c83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR does two things: the MUI v6 upgrade, plus a fix for a circular-import crash in the Table hooks.

---

## 1. Bug fix: Table circular-import crash (`reading 'string'`)

**Symptom:** consumers importing the package main barrel hit `Uncaught TypeError: Cannot read properties of undefined (reading 'string')` at app load (seen in Observe staging).

**Cause:** `Table/hooks/useUrlFilters.ts` read `urlFilterParsers.string` at **module-init**, while it and `Table/tableUtils.ts` imported the package **main barrel** (`../../main` / `../../../main`). That created a dependency cycle (`main → components → Table → useUrlFilters → tableUtils → main`) which left `tableUtils` half-initialized — so `urlFilterParsers` was `undefined` when the top-level access ran.

**Fix:**
- `useUrlFilters.ts` — moved `urlFilterParsers.string` out of the module-level const into the hook's call-time default (so it's read after all modules initialize).
- `useUrlFilters.ts` + `tableUtils.ts` — import `Utils` from `#utils` directly instead of the `../../main` barrel, breaking the cycle.

**Verified:** built the package, ran it through an Observe production preview — the load crash is gone.

---

## 2. MUI v6 upgrade

Upgrades `@mui/material` from v5 to **v6.5.0**.

- **devDependency** → `^6.5.0`
- **peerDependency** → `^5.11.1 || ^6.5.0` (dual range — consumers on either major can use the library; no forced breaking bump)

### Why it's safe

The library's MUI surface is small (~36 import sites, 16 components) and uses only APIs that are unchanged across v5→v6:

`IconButton`, `Popper`, `Paper`, `Grow`, `ClickAwayListener`, `Popover`, `Tooltip`, `CircularProgress`, `FormControl`, `Radio`, `Dialog`/`DialogActions`/`DialogContent`/`DialogTitle`, `Select`/`MenuItem`, `Divider`, `MenuList`, `Switch`, and `createTheme` (`palette`/`typography`/`styleOverrides`).

None of the major v6 breaking changes apply:
- No `Grid` (v6 Grid rewrite) · no `Hidden` (removed) · no `@mui/styles`/`makeStyles`/`withStyles` (removed) · no `@mui/x-date-pickers`/`lab`/`icons-material`.
- The `components=` props in the codebase belong to **react-select / react-markdown**, not MUI.
- Peer deps already satisfy v6: React 18.3.1, `@emotion` 11.14, TypeScript 5.9.3.

### Verification

| Check | Result |
|---|---|
| `yarn install` | ✅ no MUI peer conflicts |
| `yarn build` (vite) | ✅ pass (~7.5s) |
| `yarn test:run` | ✅ **1037/1037** pass (96 files) |
| `yarn typecheck` | error count **identical to v5** (392 pre-existing, 0 referencing MUI/emotion) |

The 392 typecheck errors are pre-existing repo type-debt (`lib/svgs` decls, react-hook-form `ControlInputs`, `storybook-solidjs` stories) and are unchanged by this bump.

> Note: the Storybook webpack build was not separately re-run (the vite build + full test suite were); no breaking MUI components appear in stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)