### PR TITLE
feat(Table): drawer slot, column pinning & cell enhancements for NeuralMesh (WEKAPP-635082)

### DIFF
--- a/lib/v2/components/CapacityProgressBar/capacityProgressBar.module.scss
+++ b/lib/v2/components/CapacityProgressBar/capacityProgressBar.module.scss
@@ -37,4 +37,7 @@
   font-weight: 600;
   z-index: 2;
   position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
 }

--- a/lib/v2/components/CapacityProgressBar/capacityProgressBar.module.scss
+++ b/lib/v2/components/CapacityProgressBar/capacityProgressBar.module.scss
@@ -36,5 +36,5 @@
   color: var(--gray-950-20);
   font-weight: 600;
   z-index: 2;
-  position: relative;
+  position: absolute;
 }

--- a/lib/v2/components/MenuPopover/MenuPopover.test.tsx
+++ b/lib/v2/components/MenuPopover/MenuPopover.test.tsx
@@ -113,7 +113,7 @@ describe('MenuPopover', () => {
   describe('Positioning', () => {
     it('applies fixed position style', () => {
       const anchorRef = createMockAnchorRef()
-      const { container } = render(
+      render(
         <MenuPopover
           anchorRef={anchorRef as unknown as RefObject<HTMLElement>}
           onClose={vi.fn()}
@@ -123,7 +123,7 @@ describe('MenuPopover', () => {
         </MenuPopover>
       )
 
-      const popover = container.querySelector('[class*="popover"]')
+      const popover = document.body.querySelector('[class*="popover"]')
       expect(popover).toHaveStyle({ position: 'fixed' })
     })
   })

--- a/lib/v2/components/MenuPopover/MenuPopover.tsx
+++ b/lib/v2/components/MenuPopover/MenuPopover.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, type RefObject, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import clsx from 'clsx'
 
 import { useClickOutside, usePopoverPosition } from '#v2/hooks'
@@ -42,13 +43,14 @@ export function MenuPopover({
     return null
   }
 
-  return (
+  return createPortal(
     <div
       ref={popRef}
       className={clsx(styles.popover, extraClass)}
       style={position}
     >
       {children}
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/lib/v2/components/Popup/Popup.tsx
+++ b/lib/v2/components/Popup/Popup.tsx
@@ -90,8 +90,12 @@ export function Popup({
           </button>
         </div>
         <div
-          className={styles.content}
           style={{ overflow: contentOverflow }}
+          className={clsx(
+            styles.content,
+            contentOverflow === CONTENT_OVERFLOWS.HIDDEN &&
+              styles.contentNoScrollbar
+          )}
         >
           {children}
         </div>

--- a/lib/v2/components/Popup/popup.module.scss
+++ b/lib/v2/components/Popup/popup.module.scss
@@ -63,6 +63,11 @@
   }
 }
 
+.contentNoScrollbar {
+  padding-right: 0;
+  scrollbar-gutter: auto;
+}
+
 .actions {
   padding-top: 24px;
   display: flex;

--- a/lib/v2/components/Table/CapabilitiesCell/CapabilitiesCell.stories.tsx
+++ b/lib/v2/components/Table/CapabilitiesCell/CapabilitiesCell.stories.tsx
@@ -1,0 +1,129 @@
+import type { CapabilitiesCellProps } from './CapabilitiesCell'
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { CellStoryTable } from '../CellStoryTable'
+import { CapabilitiesCell } from './CapabilitiesCell'
+
+const meta: Meta<typeof CapabilitiesCell> = {
+  title: 'v2/Table/Cells/CapabilitiesCell',
+  component: CapabilitiesCell,
+  argTypes: {
+    thinlyProvisioned: { control: 'boolean' },
+    tiered: { control: 'boolean' },
+    encrypted: { control: 'boolean' }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof CapabilitiesCell>
+
+export const Playground: Story = {
+  args: {
+    thinlyProvisioned: true,
+    tiered: true,
+    encrypted: true
+  }
+}
+
+export const AllBadges: Story = {
+  args: {
+    thinlyProvisioned: true,
+    tiered: true,
+    encrypted: true
+  }
+}
+
+export const ThinOnly: Story = {
+  args: {
+    thinlyProvisioned: true
+  }
+}
+
+export const TierOnly: Story = {
+  args: {
+    tiered: true
+  }
+}
+
+export const EncryptedOnly: Story = {
+  args: {
+    encrypted: true
+  }
+}
+
+export const ThinAndEncrypted: Story = {
+  args: {
+    thinlyProvisioned: true,
+    encrypted: true
+  }
+}
+
+export const NoBadges: Story = {
+  args: {}
+}
+
+interface Row {
+  name: string
+  thinlyProvisioned: boolean
+  tiered: boolean
+  encrypted: boolean
+}
+
+const SAMPLE_ROWS: Row[] = [
+  {
+    name: 'default',
+    thinlyProvisioned: false,
+    tiered: false,
+    encrypted: false
+  },
+  { name: 'thin-fs', thinlyProvisioned: true, tiered: false, encrypted: false },
+  {
+    name: 'tiered-fs',
+    thinlyProvisioned: false,
+    tiered: true,
+    encrypted: false
+  },
+  { name: 'enc-fs', thinlyProvisioned: false, tiered: false, encrypted: true },
+  {
+    name: 'thin-tiered',
+    thinlyProvisioned: true,
+    tiered: true,
+    encrypted: false
+  },
+  {
+    name: 'all-caps',
+    thinlyProvisioned: true,
+    tiered: true,
+    encrypted: true
+  }
+]
+
+const columns: ColumnDef<Row, CapabilitiesCellProps>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Filesystem',
+    size: 140
+  },
+  {
+    id: 'capabilities',
+    header: 'Capabilities',
+    size: 200,
+    cell: ({ row }) => (
+      <CapabilitiesCell
+        encrypted={row.original.encrypted}
+        thinlyProvisioned={row.original.thinlyProvisioned}
+        tiered={row.original.tiered}
+      />
+    )
+  }
+]
+
+export const InTable: Story = {
+  render: () => (
+    <CellStoryTable
+      columns={columns}
+      data={SAMPLE_ROWS}
+    />
+  )
+}

--- a/lib/v2/components/Table/CapabilitiesCell/CapabilitiesCell.test.tsx
+++ b/lib/v2/components/Table/CapabilitiesCell/CapabilitiesCell.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { CapabilitiesCell } from './CapabilitiesCell'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CapabilitiesCell — badge visibility', () => {
+  it('renders no badges and returns null when no flags are set', () => {
+    const { container } = render(<CapabilitiesCell />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders only the Thin badge when thinlyProvisioned is true', () => {
+    render(<CapabilitiesCell thinlyProvisioned />)
+    expect(screen.getByText('Thin')).toBeInTheDocument()
+    expect(screen.queryByText('Tier')).not.toBeInTheDocument()
+    expect(screen.queryByText('Enc.')).not.toBeInTheDocument()
+  })
+
+  it('renders only the Tier badge when tiered is true', () => {
+    render(<CapabilitiesCell tiered />)
+    expect(screen.getByText('Tier')).toBeInTheDocument()
+    expect(screen.queryByText('Thin')).not.toBeInTheDocument()
+    expect(screen.queryByText('Enc.')).not.toBeInTheDocument()
+  })
+
+  it('renders only the Enc. badge when encrypted is true', () => {
+    render(<CapabilitiesCell encrypted />)
+    expect(screen.getByText('Enc.')).toBeInTheDocument()
+    expect(screen.queryByText('Thin')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tier')).not.toBeInTheDocument()
+  })
+
+  it('renders all three badges when all flags are true', () => {
+    render(
+      <CapabilitiesCell
+        encrypted
+        thinlyProvisioned
+        tiered
+      />
+    )
+    expect(screen.getByText('Thin')).toBeInTheDocument()
+    expect(screen.getByText('Tier')).toBeInTheDocument()
+    expect(screen.getByText('Enc.')).toBeInTheDocument()
+  })
+
+  it('renders Thin and Enc. but not Tier when tiered is false', () => {
+    render(
+      <CapabilitiesCell
+        encrypted
+        thinlyProvisioned
+      />
+    )
+    expect(screen.getByText('Thin')).toBeInTheDocument()
+    expect(screen.queryByText('Tier')).not.toBeInTheDocument()
+    expect(screen.getByText('Enc.')).toBeInTheDocument()
+  })
+})
+
+describe('CapabilitiesCell — badge order', () => {
+  it('renders badges in Thin → Tier → Enc. order', () => {
+    render(
+      <CapabilitiesCell
+        encrypted
+        thinlyProvisioned
+        tiered
+      />
+    )
+    const badges = screen.getAllByText(/Thin|Tier|Enc\./)
+    expect(badges[0]).toHaveTextContent('Thin')
+    expect(badges[1]).toHaveTextContent('Tier')
+    expect(badges[2]).toHaveTextContent('Enc.')
+  })
+})
+
+describe('CapabilitiesCell — false flags', () => {
+  it('does not render a badge when its flag is explicitly false', () => {
+    render(
+      <CapabilitiesCell
+        encrypted={false}
+        thinlyProvisioned={false}
+        tiered={false}
+      />
+    )
+    expect(screen.queryByText('Thin')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tier')).not.toBeInTheDocument()
+    expect(screen.queryByText('Enc.')).not.toBeInTheDocument()
+  })
+})

--- a/lib/v2/components/Table/CapabilitiesCell/CapabilitiesCell.tsx
+++ b/lib/v2/components/Table/CapabilitiesCell/CapabilitiesCell.tsx
@@ -1,0 +1,58 @@
+import clsx from 'clsx'
+
+import styles from './capabilitiesCell.module.scss'
+
+export interface CapabilitiesCellProps {
+  thinlyProvisioned?: boolean
+  tiered?: boolean
+  encrypted?: boolean
+}
+
+interface BadgeConfig {
+  key: string
+  label: string
+  className: string
+  isActive: (props: CapabilitiesCellProps) => boolean
+}
+
+const BADGE_CONFIGS: BadgeConfig[] = [
+  {
+    key: 'thin',
+    label: 'Thin',
+    className: styles.badgeThin,
+    isActive: (p) => Boolean(p.thinlyProvisioned)
+  },
+  {
+    key: 'tier',
+    label: 'Tier',
+    className: styles.badgeTier,
+    isActive: (p) => Boolean(p.tiered)
+  },
+  {
+    key: 'encrypted',
+    label: 'Enc.',
+    className: styles.badgeEncrypted,
+    isActive: (p) => Boolean(p.encrypted)
+  }
+]
+
+export function CapabilitiesCell(props: Readonly<CapabilitiesCellProps>) {
+  const activeBadges = BADGE_CONFIGS.filter(({ isActive }) => isActive(props))
+
+  if (activeBadges.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={styles.container}>
+      {activeBadges.map(({ key, label, className }) => (
+        <div
+          key={key}
+          className={clsx(styles.badge, className)}
+        >
+          {label}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/lib/v2/components/Table/CapabilitiesCell/capabilitiesCell.module.scss
+++ b/lib/v2/components/Table/CapabilitiesCell/capabilitiesCell.module.scss
@@ -1,0 +1,35 @@
+@use '../../../styles/colors' as *;
+
+.container {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+   flex-wrap: nowrap;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 20px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 700;
+  white-space: nowrap;
+  color: #{$gray-0};
+}
+
+.badgeThin {
+  background: linear-gradient(0deg, $fuchsia-500 0%, $fuchsia-300 100%);
+}
+
+.badgeTier {
+  background: linear-gradient(0deg, $purple-500 0%, $purple-300 100%);
+}
+
+.badgeEncrypted {
+  background: linear-gradient(0deg, $peach-600 0%, $peach-400 100%);
+}

--- a/lib/v2/components/Table/CapabilitiesCell/index.ts
+++ b/lib/v2/components/Table/CapabilitiesCell/index.ts
@@ -1,0 +1,2 @@
+export type { CapabilitiesCellProps } from './CapabilitiesCell'
+export { CapabilitiesCell } from './CapabilitiesCell'

--- a/lib/v2/components/Table/CapacityCell/CapacityCell.stories.tsx
+++ b/lib/v2/components/Table/CapacityCell/CapacityCell.stories.tsx
@@ -17,10 +17,19 @@ interface FilesystemRow {
   total: number
   unitType?: string
   unlimitedWhenZero?: boolean
+  badge?: { label: string; tooltip?: string }
 }
 
 const ROWS: FilesystemRow[] = [
-  { name: 'fs-prod', used: 2_600_000_000, total: 4_000_000_000 },
+  {
+    name: 'fs-prod',
+    used: 2_600_000_000,
+    total: 4_000_000_000,
+    badge: {
+      label: 'TP',
+      tooltip: 'Thinly Provisioned Filesystem\nMax SSD: 4 GB\nMin SSD: 1 GB'
+    }
+  },
   { name: 'fs-archive', used: 980_000_000, total: 50_000_000_000 },
   { name: 'fs-scratch', used: 3_900_000_000, total: 4_000_000_000 },
   {
@@ -81,6 +90,7 @@ function CapacityCellDemo() {
               <td style={CELL_STYLE}>{row.name}</td>
               <td style={CELL_STYLE}>
                 <CapacityCell
+                  badge={row.badge}
                   total={row.total}
                   unitType={row.unitType}
                   unlimitedWhenZero={row.unlimitedWhenZero}

--- a/lib/v2/components/Table/CapacityCell/CapacityCell.test.tsx
+++ b/lib/v2/components/Table/CapacityCell/CapacityCell.test.tsx
@@ -44,4 +44,25 @@ describe('CapacityCell', () => {
     )
     expect(screen.getByText('Unlimited')).toBeInTheDocument()
   })
+
+  it('renders the optional badge label when a badge is provided', () => {
+    render(
+      <CapacityCell
+        badge={{ label: 'TP', tooltip: 'Thinly Provisioned' }}
+        total={TOTAL_BYTES}
+        used={USED_BYTES}
+      />
+    )
+    expect(screen.getByText('TP')).toBeInTheDocument()
+  })
+
+  it('renders no badge by default', () => {
+    render(
+      <CapacityCell
+        total={TOTAL_BYTES}
+        used={USED_BYTES}
+      />
+    )
+    expect(screen.queryByText('TP')).not.toBeInTheDocument()
+  })
 })

--- a/lib/v2/components/Table/CapacityCell/CapacityCell.tsx
+++ b/lib/v2/components/Table/CapacityCell/CapacityCell.tsx
@@ -1,29 +1,43 @@
+import type { ReactElement } from 'react'
+
 import { formatCapacitySmart, UNIT_TYPES } from '#v2/utils/capacityUtils'
 import { PERCENTAGE } from '#v2/utils/consts'
 
 import { CapacityProgressBar } from '../../CapacityProgressBar'
+import { Tooltip } from '../../Tooltip'
 
 import styles from './capacityCell.module.scss'
 
 const UNLIMITED_LABEL = 'Unlimited'
+
+export interface CapacityCellBadge {
+  label: string
+  tooltip?: string | ReactElement
+}
 
 export interface CapacityCellProps {
   used: number
   total: number
   unlimitedWhenZero?: boolean
   unitType?: string
+  badge?: CapacityCellBadge
 }
 
 export function CapacityCell({
   used,
   total,
   unlimitedWhenZero,
-  unitType = UNIT_TYPES.BASE10
+  unitType = UNIT_TYPES.BASE10,
+  badge
 }: Readonly<CapacityCellProps>) {
   const isUnlimited = unlimitedWhenZero && total === 0
   const percentage = total > 0 ? (used / total) * PERCENTAGE.FULL : 0
   const usedFormatted = formatCapacitySmart({ bytes: used, unitType })
   const totalFormatted = formatCapacitySmart({ bytes: total, unitType })
+
+  const badgePill = badge ? (
+    <span className={styles.badge}>{badge.label}</span>
+  ) : null
 
   return (
     <div className={styles.capacityCell}>
@@ -47,6 +61,11 @@ export function CapacityCell({
             <span className={styles.number}>{totalFormatted.value}</span>
             <span className={styles.unit}>{totalFormatted.unit}</span>
           </span>
+        )}
+        {badge?.tooltip ? (
+          <Tooltip data={badge.tooltip}>{badgePill}</Tooltip>
+        ) : (
+          badgePill
         )}
       </div>
     </div>

--- a/lib/v2/components/Table/CapacityCell/capacityCell.module.scss
+++ b/lib/v2/components/Table/CapacityCell/capacityCell.module.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/colors' as *;
+
 .capacityCell {
   display: grid;
   grid-template-columns: 60% 1fr;
@@ -44,4 +46,17 @@
 
 .unit {
   font-size: 12px;
+}
+
+.badge {
+  flex-shrink: 0;
+  margin-left: 6px;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  color: $gray-0;
+  background: linear-gradient(0deg, $cyan-500, $cyan-300);
+  cursor: default;
 }

--- a/lib/v2/components/Table/DefaultCell/DefaultCell.stories.tsx
+++ b/lib/v2/components/Table/DefaultCell/DefaultCell.stories.tsx
@@ -21,25 +21,33 @@ interface Row {
   description: DefaultCellValue
   internalLink: DefaultCellValue
   externalLink: DefaultCellValue
+  boldName: DefaultCellValue
 }
+
+const CLUSTER_PROD_1 = 'cluster-prod-1'
+const CLUSTER_PROD_2 = 'cluster-prod-2'
+const LINK_VIEW_DETAILS = 'View details'
+const LINK_OPEN_DOCS = 'Open docs'
 
 const SAMPLE_ROWS: Row[] = [
   {
-    id: 'cluster-prod-1',
-    name: 'cluster-prod-1',
+    id: CLUSTER_PROD_1,
+    name: CLUSTER_PROD_1,
     protocols: ['NFS', 'SMB', 'S3'],
     description:
       'Production cluster running in us-east-1, handling primary workloads and serving as the source of truth for replication.',
-    internalLink: 'View details',
-    externalLink: 'Open docs'
+    internalLink: LINK_VIEW_DETAILS,
+    externalLink: LINK_OPEN_DOCS,
+    boldName: CLUSTER_PROD_1
   },
   {
-    id: 'cluster-prod-2',
-    name: 'cluster-prod-2',
+    id: CLUSTER_PROD_2,
+    name: CLUSTER_PROD_2,
     protocols: ['NFS'],
     description: 'Secondary production cluster.',
-    internalLink: 'View details',
-    externalLink: 'Open docs'
+    internalLink: LINK_VIEW_DETAILS,
+    externalLink: LINK_OPEN_DOCS,
+    boldName: CLUSTER_PROD_2
   },
   {
     id: 'cluster-empty',
@@ -47,7 +55,8 @@ const SAMPLE_ROWS: Row[] = [
     protocols: [],
     description: undefined,
     internalLink: null,
-    externalLink: null
+    externalLink: null,
+    boldName: null
   }
 ]
 
@@ -91,6 +100,17 @@ const columns: ColumnDef<Row, DefaultCellValue>[] = [
         getUrl: () => 'https://docs.weka.io',
         openInNewTab: true,
         tooltipText: 'Opens in a new tab'
+      } satisfies DefaultCellOptions<Row>
+    } as ColumnDef<Row, DefaultCellValue>['meta']
+  },
+  {
+    accessorKey: 'boldName',
+    header: 'Bold name',
+    cell: DefaultCell,
+    size: 160,
+    meta: {
+      cellOptions: {
+        bold: true
       } satisfies DefaultCellOptions<Row>
     } as ColumnDef<Row, DefaultCellValue>['meta']
   }

--- a/lib/v2/components/Table/DefaultCell/DefaultCell.test.tsx
+++ b/lib/v2/components/Table/DefaultCell/DefaultCell.test.tsx
@@ -131,6 +131,34 @@ describe('DefaultCell - link rendering', () => {
   })
 })
 
+const BOLD_SELECTOR = '[class*="bold"]'
+
+describe('DefaultCell - bold option', () => {
+  it('applies the bold class when bold option is true', () => {
+    const ctx = buildCellContext({
+      value: 'bold text',
+      cellOptions: { bold: true }
+    })
+    const { container } = renderCell(ctx)
+    expect(container.querySelector(BOLD_SELECTOR)).toBeInTheDocument()
+  })
+
+  it('does not apply the bold class when bold option is false', () => {
+    const ctx = buildCellContext({
+      value: 'normal text',
+      cellOptions: { bold: false }
+    })
+    const { container } = renderCell(ctx)
+    expect(container.querySelector(BOLD_SELECTOR)).not.toBeInTheDocument()
+  })
+
+  it('does not apply the bold class when bold option is not set', () => {
+    const ctx = buildCellContext({ value: 'normal text' })
+    const { container } = renderCell(ctx)
+    expect(container.querySelector(BOLD_SELECTOR)).not.toBeInTheDocument()
+  })
+})
+
 describe('DefaultCell - custom tooltip', () => {
   it('exposes string tooltipText via aria-label on the wrapper', () => {
     const TOOLTIP_BODY = 'custom tooltip body'

--- a/lib/v2/components/Table/DefaultCell/DefaultCell.tsx
+++ b/lib/v2/components/Table/DefaultCell/DefaultCell.tsx
@@ -1,6 +1,7 @@
 import type { CellContext } from '@tanstack/react-table'
 
 import { Link } from 'react-router-dom'
+import clsx from 'clsx'
 
 import { COMMA_SEPARATOR, EMPTY_STRING } from '#v2/utils/consts'
 
@@ -14,6 +15,7 @@ export interface DefaultCellOptions<TData> {
   tooltipText?:
     | string
     | ((cell: CellContext<TData, DefaultCellValue>) => string)
+  bold?: boolean
 }
 
 export type DefaultCellValue = string | number | string[] | null | undefined
@@ -43,7 +45,8 @@ export function DefaultCell<TData>(
   const {
     getUrl,
     openInNewTab,
-    tooltipText: customTooltipText
+    tooltipText: customTooltipText,
+    bold
   } = cellOptions ?? {}
 
   const customTooltip =
@@ -51,7 +54,11 @@ export function DefaultCell<TData>(
       ? customTooltipText(props)
       : customTooltipText
 
-  const cellContent = <div className={styles.defaultCell}>{formattedValue}</div>
+  const cellContent = (
+    <div className={clsx(styles.defaultCell, bold && styles.bold)}>
+      {formattedValue}
+    </div>
+  )
 
   if (customTooltip) {
     return (
@@ -82,7 +89,7 @@ export function DefaultCell<TData>(
     <Tooltip
       data={formattedValue}
       ellipsis
-      ellipsisClass={styles.defaultCell}
+      ellipsisClass={clsx(styles.defaultCell, bold && styles.bold)}
       extraClass={styles.cellTooltip}
     >
       {getUrl ? (

--- a/lib/v2/components/Table/DefaultCell/defaultCell.module.scss
+++ b/lib/v2/components/Table/DefaultCell/defaultCell.module.scss
@@ -17,3 +17,7 @@
   max-width: 400px !important;
   overflow-wrap: break-word;
 }
+
+.bold {
+  font-weight: 700;
+}

--- a/lib/v2/components/Table/RowActionsCell/RowActionsCell.test.tsx
+++ b/lib/v2/components/Table/RowActionsCell/RowActionsCell.test.tsx
@@ -80,7 +80,9 @@ describe('RowActionsCell', () => {
     const hidden: RowAction<TestRow>[] = [
       { key: 'edit', text: EDIT_TEXT, action: vi.fn(), hideAction: () => true }
     ]
-    const { rerender } = render(<RowActionsCell {...buildCellContext(visible)} />)
+    const { rerender } = render(
+      <RowActionsCell {...buildCellContext(visible)} />
+    )
 
     fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
     expect(screen.getByTestId(EDIT_ACTION_TESTID)).toBeInTheDocument()
@@ -98,7 +100,12 @@ describe('RowActionsCell', () => {
   it('does not render actions whose hideAction returns true', () => {
     renderCell([
       { key: 'edit', text: EDIT_TEXT, action: vi.fn() },
-      { key: 'archive', text: 'Archive', action: vi.fn(), hideAction: () => true }
+      {
+        key: 'archive',
+        text: 'Archive',
+        action: vi.fn(),
+        hideAction: () => true
+      }
     ])
     fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
     expect(screen.getByTestId(EDIT_ACTION_TESTID)).toBeInTheDocument()
@@ -124,7 +131,9 @@ describe('RowActionsCell', () => {
   it('passes the row to hideAction and disabled predicates', () => {
     const hideAction = vi.fn(() => false)
     const disabled = vi.fn(() => false)
-    renderCell([{ key: 'edit', text: EDIT_TEXT, action: vi.fn(), hideAction, disabled }])
+    renderCell([
+      { key: 'edit', text: EDIT_TEXT, action: vi.fn(), hideAction, disabled }
+    ])
     fireEvent.click(screen.getByTestId(ROW_ACTIONS_BUTTON_TESTID))
     expect(hideAction).toHaveBeenCalledWith(SAMPLE_ROW)
     expect(disabled).toHaveBeenCalledWith(SAMPLE_ROW)
@@ -148,7 +157,9 @@ describe('RowActionsCell', () => {
     render(
       <div onClick={onParentClick}>
         <RowActionsCell
-          {...buildCellContext([{ key: 'edit', text: EDIT_TEXT, action: vi.fn() }])}
+          {...buildCellContext([
+            { key: 'edit', text: EDIT_TEXT, action: vi.fn() }
+          ])}
         />
       </div>
     )
@@ -178,7 +189,9 @@ describe('RowActionsCell', () => {
     render(
       <div onClick={onParentClick}>
         <RowActionsCell
-          {...buildCellContext([{ key: 'edit', text: EDIT_TEXT, action: vi.fn() }])}
+          {...buildCellContext([
+            { key: 'edit', text: EDIT_TEXT, action: vi.fn() }
+          ])}
         />
       </div>
     )

--- a/lib/v2/components/Table/RowActionsCell/rowActionsCell.module.scss
+++ b/lib/v2/components/Table/RowActionsCell/rowActionsCell.module.scss
@@ -6,5 +6,7 @@
 }
 
 .menu {
-  width: 260px;
+  width: max-content;
+  min-width: 180px;
+  max-width: 360px;
 }

--- a/lib/v2/components/Table/Table/Table.stories.tsx
+++ b/lib/v2/components/Table/Table/Table.stories.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react'
 import { FILTER_TYPES } from '#v2/utils/consts'
 
 import { Table } from './Table'
+import { TableWithDrawerDemo } from './TableWithDrawerDemo'
 
 const meta: Meta<typeof Table> = {
   title: 'v2/Table/Table'
@@ -120,4 +121,105 @@ export const WithRowActions: Story = {
       />
     </div>
   )
+}
+
+interface WideCluster extends Cluster {
+  tier: string
+  backend: string
+  protocol: string
+  drives: number
+  capacity: string
+  iops: string
+  latency: string
+}
+
+const TIERS = ['Standard', 'Performance', 'Archive']
+const BACKENDS = ['NVMe', 'SSD', 'HDD']
+const PROTOCOLS = ['NFS', 'SMB', 'S3', 'POSIX']
+
+const WIDE_ITEM_COUNT = 20
+const DRIVES_CYCLE = 8
+const DRIVES_PER_GROUP = 4
+const IOPS_MULTIPLIER = 50
+const LATENCY_CYCLE = 5
+const LATENCY_STEP = 0.1
+const WIDE_CONTAINER_MAX_WIDTH = 800
+
+const WIDE_DATA: WideCluster[] = Array.from(
+  { length: WIDE_ITEM_COUNT },
+  (_unused, index) => ({
+    id: index + 1,
+    name: `cluster-${index + 1}`,
+    region: REGIONS[index % REGIONS.length],
+    status: STATUSES[index % STATUSES.length],
+    tier: TIERS[index % TIERS.length],
+    backend: BACKENDS[index % BACKENDS.length],
+    protocol: PROTOCOLS[index % PROTOCOLS.length],
+    drives: ((index % DRIVES_CYCLE) + 1) * DRIVES_PER_GROUP,
+    capacity: `${(index + 1) * 10} TB`,
+    iops: `${(index + 1) * IOPS_MULTIPLIER}K`,
+    latency: `${((index % LATENCY_CYCLE) + 1) * LATENCY_STEP}ms`
+  })
+)
+
+const WIDE_COLUMNS: ColumnDef<WideCluster>[] = [
+  { accessorKey: 'name', header: 'Name', size: 180 },
+  { accessorKey: 'region', header: 'Region', size: 160 },
+  { accessorKey: 'status', header: 'Status', size: 140 },
+  { accessorKey: 'tier', header: 'Tier', size: 140 },
+  { accessorKey: 'backend', header: 'Backend', size: 140 },
+  { accessorKey: 'protocol', header: 'Protocol', size: 140 },
+  { accessorKey: 'drives', header: 'Drives', size: 120 },
+  { accessorKey: 'capacity', header: 'Capacity', size: 140 },
+  { accessorKey: 'iops', header: 'IOPS', size: 120 },
+  { accessorKey: 'latency', header: 'Latency', size: 120 }
+]
+
+const WIDE_CONTAINER_STYLE = {
+  ...CONTAINER_STYLE,
+  maxWidth: WIDE_CONTAINER_MAX_WIDTH
+}
+
+const WIDE_ROW_ACTIONS: RowAction<WideCluster>[] = [
+  {
+    key: 'edit',
+    text: 'Edit',
+    action: (row) => alert(`Edit ${row.name}`)
+  },
+  {
+    key: 'delete',
+    text: 'Delete',
+    action: (row) => alert(`Delete ${row.name}`)
+  }
+]
+
+export const WithRowActionsAndHorizontalScroll: Story = {
+  render: () => (
+    <div style={WIDE_CONTAINER_STYLE}>
+      <Table
+        columns={WIDE_COLUMNS}
+        data={WIDE_DATA}
+        rowActions={WIDE_ROW_ACTIONS}
+        title='Wide table — scroll right to see sticky actions column'
+      />
+    </div>
+  )
+}
+
+export const WithPinFirstColumn: Story = {
+  render: () => (
+    <div style={WIDE_CONTAINER_STYLE}>
+      <Table
+        columns={WIDE_COLUMNS}
+        data={WIDE_DATA}
+        pinFirstColumn
+        rowActions={WIDE_ROW_ACTIONS}
+        title='Wide table — first column pinned left, actions pinned right'
+      />
+    </div>
+  )
+}
+
+export const WithDrawerSlot: Story = {
+  render: () => <TableWithDrawerDemo />
 }

--- a/lib/v2/components/Table/Table/Table.test.tsx
+++ b/lib/v2/components/Table/Table/Table.test.tsx
@@ -260,7 +260,9 @@ describe('Table rowActions', () => {
     )
     const [firstButton] = screen.getAllByTestId(ROW_ACTIONS_BUTTON_TESTID)
     fireEvent.click(firstButton)
-    expect(screen.queryByTestId('row-action-hidden-action')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('row-action-hidden-action')
+    ).not.toBeInTheDocument()
   })
 
   it('renders disabled actions as disabled', () => {
@@ -296,7 +298,12 @@ describe('Table rowActions', () => {
 
   it('renders no kebab button when all actions are hidden for a row', () => {
     const actions: RowAction<Item>[] = [
-      { key: 'always-hidden', text: 'Hidden', action: vi.fn(), hideAction: () => true }
+      {
+        key: 'always-hidden',
+        text: 'Hidden',
+        action: vi.fn(),
+        hideAction: () => true
+      }
     ]
     render(
       <Table
@@ -305,7 +312,217 @@ describe('Table rowActions', () => {
         rowActions={actions}
       />
     )
-    expect(screen.queryByTestId(ROW_ACTIONS_BUTTON_TESTID)).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId(ROW_ACTIONS_BUTTON_TESTID)
+    ).not.toBeInTheDocument()
+  })
+
+  it('applies stickyActions class to the actions header cell and body cells', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        rowActions={ROW_ACTIONS}
+      />
+    )
+
+    // The last <th> in the header row should have the stickyActions class
+    const headerRow = container.querySelector('thead tr')
+    const headerCells = Array.from(headerRow?.querySelectorAll('th') ?? [])
+    const lastHeaderCell = headerCells.at(-1)
+    expect(lastHeaderCell).toHaveClass('stickyActions')
+
+    // Every last <td> in each body row should have the stickyActions class
+    const bodyRows = container.querySelectorAll('tbody tr')
+    bodyRows.forEach((row) => {
+      const cells = Array.from(row.querySelectorAll('td'))
+      const lastCell = cells.at(-1)
+      expect(lastCell).toHaveClass('stickyActions')
+    })
+  })
+
+  it('does not apply stickyActions class when rowActions are not provided', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+      />
+    )
+
+    // No cell should have the stickyActions class
+    const stickyCells = container.querySelectorAll('.stickyActions')
+    expect(stickyCells).toHaveLength(0)
+  })
+})
+
+describe('Table pinFirstColumn', () => {
+  it('applies stickyFirst class to first header cell and first body cells when pinFirstColumn is true', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        pinFirstColumn
+      />
+    )
+
+    // The first <th> in the header row should have the stickyFirst class
+    const headerRow = container.querySelector('thead tr')
+    const headerCells = Array.from(headerRow?.querySelectorAll('th') ?? [])
+    const firstHeaderCell = headerCells.at(0)
+    expect(firstHeaderCell).toHaveClass('stickyFirst')
+
+    // The second <th> should NOT have stickyFirst
+    const secondHeaderCell = headerCells.at(1)
+    expect(secondHeaderCell).not.toHaveClass('stickyFirst')
+
+    // Every first <td> in each body row should have the stickyFirst class
+    const bodyRows = container.querySelectorAll('tbody tr')
+    bodyRows.forEach((row) => {
+      const cells = Array.from(row.querySelectorAll('td'))
+      const firstCell = cells.at(0)
+      expect(firstCell).toHaveClass('stickyFirst')
+      // Last cell should NOT have stickyFirst
+      const lastCell = cells.at(-1)
+      expect(lastCell).not.toHaveClass('stickyFirst')
+    })
+  })
+
+  it('does not apply stickyFirst class when pinFirstColumn is false', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+      />
+    )
+
+    const stickyCells = container.querySelectorAll('.stickyFirst')
+    expect(stickyCells).toHaveLength(0)
+  })
+
+  it('applies both stickyFirst and stickyActions when pinFirstColumn is true and rowActions are provided', () => {
+    const ROW_ACTIONS: RowAction<Item>[] = [
+      { key: 'edit', text: 'Edit', action: vi.fn() }
+    ]
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        pinFirstColumn
+        rowActions={ROW_ACTIONS}
+      />
+    )
+
+    const headerRow = container.querySelector('thead tr')
+    const headerCells = Array.from(headerRow?.querySelectorAll('th') ?? [])
+
+    // First header cell gets stickyFirst
+    expect(headerCells.at(0)).toHaveClass('stickyFirst')
+    // Last header cell (actions) gets stickyActions
+    expect(headerCells.at(-1)).toHaveClass('stickyActions')
+
+    // Verify body rows have both classes
+    const bodyRows = container.querySelectorAll('tbody tr')
+    bodyRows.forEach((row) => {
+      const cells = Array.from(row.querySelectorAll('td'))
+      expect(cells.at(0)).toHaveClass('stickyFirst')
+      expect(cells.at(-1)).toHaveClass('stickyActions')
+    })
+  })
+})
+
+describe('Table drawer slot', () => {
+  const DRAWER_TESTID = 'my-drawer'
+  const TABLE_BODY_AREA_SELECTOR = '.tableBodyArea'
+  const TABLE_BODY_MAIN_SELECTOR = '.tableBodyMain'
+  const TABLE_FOOTER_SELECTOR = '.tableFooter'
+
+  it('renders the drawer node when drawer prop is provided', () => {
+    render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        drawer={<div data-testid={DRAWER_TESTID}>Drawer content</div>}
+      />
+    )
+    expect(screen.getByTestId(DRAWER_TESTID)).toBeInTheDocument()
+  })
+
+  it('does not render a tableBodyArea wrapper when drawer is absent', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+      />
+    )
+    expect(
+      container.querySelector(TABLE_BODY_AREA_SELECTOR)
+    ).not.toBeInTheDocument()
+  })
+
+  it('applies margin-right to tableBodyMain when drawerOpen is true', () => {
+    const DRAWER_WIDTH = 320
+    const EXPECTED_GAP = 24
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        drawer={<div data-testid={DRAWER_TESTID}>Drawer</div>}
+        drawerOpen
+        drawerWidth={DRAWER_WIDTH}
+      />
+    )
+    const tableBodyArea = container.querySelector(TABLE_BODY_AREA_SELECTOR)
+    expect(tableBodyArea).toBeInTheDocument()
+    const tableBodyMain = tableBodyArea?.querySelector(TABLE_BODY_MAIN_SELECTOR)
+    expect(tableBodyMain).toHaveStyle({
+      marginRight: `${DRAWER_WIDTH + EXPECTED_GAP}px`
+    })
+  })
+
+  it('applies no margin-right when drawerOpen is false', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        drawer={<div data-testid={DRAWER_TESTID}>Drawer</div>}
+        drawerOpen={false}
+        drawerWidth={320}
+      />
+    )
+    const tableBodyArea = container.querySelector(TABLE_BODY_AREA_SELECTOR)
+    const tableBodyMain = tableBodyArea?.querySelector(TABLE_BODY_MAIN_SELECTOR)
+    expect(tableBodyMain).toHaveStyle({ marginRight: '0px' })
+  })
+
+  it('renders the footer inside tableBodyMain when drawer is present', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        drawer={<div data-testid={DRAWER_TESTID}>Drawer</div>}
+        drawerOpen
+        drawerWidth={320}
+      />
+    )
+    const tableBodyMain = container.querySelector(TABLE_BODY_MAIN_SELECTOR)
+    expect(
+      tableBodyMain?.querySelector(TABLE_FOOTER_SELECTOR)
+    ).toBeInTheDocument()
+  })
+
+  it('still renders table rows when drawer is present', () => {
+    render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        drawer={<div data-testid={DRAWER_TESTID}>Drawer</div>}
+        drawerOpen
+        drawerWidth={320}
+      />
+    )
+    expect(screen.getByText('Item 1')).toBeInTheDocument()
+    expect(screen.getByText('Item 2')).toBeInTheDocument()
+    expect(screen.getByText('Item 3')).toBeInTheDocument()
   })
 })
 

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -38,8 +38,8 @@ const DEFAULT_PAGE_SIZE = 25
 const MAX_ROWS_FOR_COMPACT = 10
 const FIRST_PAGE = 1
 const COMPACT_HALF_DIVISOR = 2
-const ROW_ACTIONS_COLUMN_ID = '__rowActions__'
 const ROW_ACTIONS_COLUMN_SIZE = 56
+const DRAWER_GAP = 24
 
 const EMPTY_ACTIVE_FILTERS: ActiveFilter[] = []
 const EMPTY_EXCLUDED_FIELDS: string[] = []
@@ -105,9 +105,63 @@ export interface TableProps<TData = unknown> {
   onCsvError?: (message: string) => void
   dataTestId?: string
   rowActions?: RowAction<TData>[]
+  pinFirstColumn?: boolean
+  drawer?: ReactNode
+  drawerOpen?: boolean
+  drawerWidth?: number
+  rowActionsWidth?: number
 }
 
+export const ROW_ACTIONS_COLUMN_ID = '__rowActions__'
+
 const COLUMN_RESIZE_MODE: ColumnResizeMode = 'onChange'
+
+interface RenderTableBodyArgs {
+  readonly drawer: ReactNode
+  readonly drawerOpen: boolean
+  readonly drawerWidth: number
+  readonly tableContainerContent: ReactNode
+  readonly footer: ReactNode
+}
+
+function renderTableBody({
+  drawer,
+  drawerOpen,
+  drawerWidth,
+  tableContainerContent,
+  footer
+}: RenderTableBodyArgs) {
+  const tableContainer = (
+    <div className={styles.tableContainer}>{tableContainerContent}</div>
+  )
+
+  if (!drawer) {
+    return (
+      <>
+        {tableContainer}
+        {footer}
+      </>
+    )
+  }
+
+  const bodyMainStyle = {
+    marginRight: drawerOpen ? `${drawerWidth + DRAWER_GAP}px` : '0px',
+    transition: 'margin-right 0.15s ease'
+  }
+
+  return (
+    <div className={styles.tableBodyArea}>
+      <div
+        className={styles.tableBodyMain}
+        style={bodyMainStyle}
+      >
+        {tableContainer}
+        {footer}
+      </div>
+      {drawer}
+    </div>
+  )
+}
 
 export function Table<TData = unknown>({
   data,
@@ -153,7 +207,12 @@ export function Table<TData = unknown>({
   onColumnVisibilityChange,
   currentPage: currentPageProp,
   isPaginationPageEnabled,
-  rowActions
+  rowActions,
+  pinFirstColumn = false,
+  drawer,
+  drawerOpen = false,
+  drawerWidth = 0,
+  rowActionsWidth = ROW_ACTIONS_COLUMN_SIZE
 }: Readonly<TableProps<TData>>) {
   const { columnVisibility, handleColumnVisibilityChange } =
     useColumnVisibility({
@@ -219,6 +278,26 @@ export function Table<TData = unknown>({
     [data, filteredData, globalSearchTerm]
   )
 
+  useEffect(() => {
+    const bodyEl = bodyRef.current
+    const headerEl = headerRef.current
+    if (!bodyEl || !headerEl) {
+      return
+    }
+
+    const syncScrollbarGutter = () => {
+      const scrollbarWidth = bodyEl.offsetWidth - bodyEl.clientWidth
+      headerEl.style.paddingRight = `${scrollbarWidth}px`
+    }
+
+    syncScrollbarGutter()
+
+    const observer = new ResizeObserver(syncScrollbarGutter)
+    observer.observe(bodyEl)
+
+    return () => observer.disconnect()
+  }, [loading, displayData, columnVisibility, drawerOpen, drawerWidth])
+
   const tableColumns = useMemo(() => {
     const builtColumns = buildTableColumns(columns, hasResizableColumns)
     if (!rowActions || rowActions.length === 0) {
@@ -231,12 +310,12 @@ export function Table<TData = unknown>({
       enableColumnFilter: false,
       enableResizing: false,
       enableHiding: false,
-      size: ROW_ACTIONS_COLUMN_SIZE,
+      size: rowActionsWidth,
       meta: { rowActions } as Record<string, unknown>,
       cell: (ctx) => <RowActionsCell {...ctx} />
     }
     return [...builtColumns, rowActionsColumn]
-  }, [columns, hasResizableColumns, rowActions])
+  }, [columns, hasResizableColumns, rowActions, rowActionsWidth])
 
   const tableOptions = useTableOptions({
     displayData,
@@ -354,6 +433,12 @@ export function Table<TData = unknown>({
     setCurrentPage(FIRST_PAGE)
   }, [activeFilters, globalSearchTerm, setCurrentPage])
 
+  const firstDataColumnId = pinFirstColumn
+    ? table
+        .getVisibleLeafColumns()
+        .find((col) => col.id !== ROW_ACTIONS_COLUMN_ID)?.id
+    : undefined
+
   const wrapperStyle = maxHeight
     ? {
         maxHeight: typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight
@@ -424,128 +509,148 @@ export function Table<TData = unknown>({
         title={title}
         useTableHeader={useTableHeader}
       />
-      <div className={styles.tableContainer}>
-        <div className={styles.tableScrollContainer}>
-          <div
-            ref={headerRef}
-            className={styles.tableHeaderWrapper}
-          >
-            <table className={styles.table}>
-              <thead className={styles.tableHeader}>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers
-                      .filter((header) => header.column.getIsVisible())
-                      .map((header) => {
-                        const columnId = header.column.id || header.id
-                        return (
-                          <th
-                            key={header.id}
-                            className={styles.headerCell}
-                            data-testid={`column-header-${columnId}`}
-                            style={{ width: header.getSize() }}
-                          >
-                            <div className={styles.headerContent}>
-                              <div className={styles.headerMain}>
-                                <div
-                                  onClick={header.column.getToggleSortingHandler()}
-                                  className={
-                                    header.column.getCanSort()
-                                      ? styles.sortableHeader
-                                      : styles.headerText
-                                  }
-                                >
-                                  {flexRender(
-                                    header.column.columnDef.header,
-                                    header.getContext()
-                                  )}
-                                </div>
-                                <div className={styles.headerIcons}>
-                                  {(getCanShowFilter(header) ||
-                                    header.column.getCanSort()) && (
-                                    <TableFilter
-                                      activeFilters={activeFilters}
-                                      canFilter={getCanShowFilter(header)}
-                                      canSort={header.column.getCanSort()}
-                                      columnId={header.column.id}
-                                      columns={columns}
-                                      customFilters={customFilters}
-                                      onFilterChange={setActiveFilters}
-                                      onSortClick={header.column.getToggleSortingHandler()}
-                                      sortDirection={header.column.getIsSorted()}
-                                    />
-                                  )}
+      {renderTableBody({
+        drawer,
+        drawerOpen,
+        drawerWidth,
+        footer: (
+          <div className={styles.tableFooter}>
+            {showPagination ? (
+              <Pagination
+                currentPage={currentPage}
+                isPageEnabled={isPaginationPageEnabled}
+                onPageChange={handlePageChange}
+                totalPages={Math.max(totalPages, FIRST_PAGE)}
+              />
+            ) : null}
+          </div>
+        ),
+        tableContainerContent: (
+          <div className={styles.tableScrollContainer}>
+            <div
+              ref={headerRef}
+              className={styles.tableHeaderWrapper}
+            >
+              <table className={styles.table}>
+                <thead className={styles.tableHeader}>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers
+                        .filter((header) => header.column.getIsVisible())
+                        .map((header) => {
+                          const columnId = header.column.id || header.id
+                          const isActionsColumn =
+                            header.column.id === ROW_ACTIONS_COLUMN_ID
+                          const isFirstColumn =
+                            header.column.id === firstDataColumnId
+                          return (
+                            <th
+                              key={header.id}
+                              data-testid={`column-header-${columnId}`}
+                              style={{ width: header.getSize() }}
+                              className={clsx(styles.headerCell, {
+                                [styles.stickyActions]: isActionsColumn,
+                                [styles.stickyFirst]: isFirstColumn
+                              })}
+                            >
+                              <div className={styles.headerContent}>
+                                <div className={styles.headerMain}>
+                                  <div
+                                    onClick={header.column.getToggleSortingHandler()}
+                                    className={
+                                      header.column.getCanSort()
+                                        ? styles.sortableHeader
+                                        : styles.headerText
+                                    }
+                                  >
+                                    {flexRender(
+                                      header.column.columnDef.header,
+                                      header.getContext()
+                                    )}
+                                  </div>
+                                  <div className={styles.headerIcons}>
+                                    {(getCanShowFilter(header) ||
+                                      header.column.getCanSort()) && (
+                                      <TableFilter
+                                        activeFilters={activeFilters}
+                                        canFilter={getCanShowFilter(header)}
+                                        canSort={header.column.getCanSort()}
+                                        columnId={header.column.id}
+                                        columns={columns}
+                                        customFilters={customFilters}
+                                        onFilterChange={setActiveFilters}
+                                        onSortClick={header.column.getToggleSortingHandler()}
+                                        sortDirection={header.column.getIsSorted()}
+                                      />
+                                    )}
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                            {hasResizableColumns &&
-                            header.column.getCanResize() ? (
-                              <div
-                                className={styles.resizer}
-                                data-testid={`column-resizer-${columnId}`}
-                                onMouseDown={header.getResizeHandler()}
-                                onTouchStart={header.getResizeHandler()}
-                              />
-                            ) : null}
-                          </th>
-                        )
-                      })}
-                  </tr>
-                ))}
-              </thead>
-            </table>
-          </div>
-          <div
-            ref={bodyRef}
-            className={styles.tableWrapper}
-            onScroll={handleBodyScroll}
-          >
-            <table
-              className={styles.table}
-              data-testid={dataTestId}
+                              {hasResizableColumns &&
+                              header.column.getCanResize() ? (
+                                <div
+                                  className={styles.resizer}
+                                  data-testid={`column-resizer-${columnId}`}
+                                  onMouseDown={header.getResizeHandler()}
+                                  onTouchStart={header.getResizeHandler()}
+                                />
+                              ) : null}
+                            </th>
+                          )
+                        })}
+                    </tr>
+                  ))}
+                </thead>
+              </table>
+            </div>
+            <div
+              ref={bodyRef}
+              className={styles.tableWrapper}
+              onScroll={handleBodyScroll}
             >
-              <tbody className={styles.tableBody}>
-                <TableContent
-                  activeRowId={activeRowId}
-                  emptyMessage={emptyMessage}
-                  getRowId={getRowId}
-                  onRowClick={onRowClick}
-                  rows={table.getRowModel().rows}
-                  renderCell={(cell) => {
-                    const cellMeta = cell.column.columnDef.meta as
-                      | { cellStyle?: CSSProperties }
-                      | undefined
-                    const cellStyle = cellMeta?.cellStyle || {}
+              <table
+                className={styles.table}
+                data-testid={dataTestId}
+              >
+                <tbody className={styles.tableBody}>
+                  <TableContent
+                    activeRowId={activeRowId}
+                    emptyMessage={emptyMessage}
+                    getRowId={getRowId}
+                    onRowClick={onRowClick}
+                    rows={table.getRowModel().rows}
+                    renderCell={(cell) => {
+                      const cellMeta = cell.column.columnDef.meta as
+                        | { cellStyle?: CSSProperties }
+                        | undefined
+                      const cellStyle = cellMeta?.cellStyle || {}
+                      const isActionsCell =
+                        cell.column.id === ROW_ACTIONS_COLUMN_ID
+                      const isFirstCell = cell.column.id === firstDataColumnId
 
-                    return (
-                      <td
-                        key={cell.id}
-                        className={styles.tableCell}
-                        style={{ width: cell.column.getSize(), ...cellStyle }}
-                      >
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )}
-                      </td>
-                    )
-                  }}
-                />
-              </tbody>
-            </table>
+                      return (
+                        <td
+                          key={cell.id}
+                          style={{ width: cell.column.getSize(), ...cellStyle }}
+                          className={clsx(styles.tableCell, {
+                            [styles.stickyActions]: isActionsCell,
+                            [styles.stickyFirst]: isFirstCell
+                          })}
+                        >
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </td>
+                      )
+                    }}
+                  />
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
-      </div>
-      <div className={styles.tableFooter}>
-        {showPagination ? (
-          <Pagination
-            currentPage={currentPage}
-            isPageEnabled={isPaginationPageEnabled}
-            onPageChange={handlePageChange}
-            totalPages={Math.max(totalPages, FIRST_PAGE)}
-          />
-        ) : null}
-      </div>
+        )
+      })}
     </div>
   )
 }

--- a/lib/v2/components/Table/Table/TableWithDrawerDemo.tsx
+++ b/lib/v2/components/Table/Table/TableWithDrawerDemo.tsx
@@ -1,0 +1,120 @@
+import type { MouseEvent } from 'react'
+
+import { useCallback, useState } from 'react'
+
+import { TableDrawer } from '../../TableDrawer'
+import { Table } from './Table'
+
+interface Cluster {
+  id: number
+  name: string
+  region: string
+  status: string
+}
+
+const REGIONS = ['us-east-1', 'us-west-2', 'eu-central-1']
+const STATUSES = ['Healthy', 'Degraded', 'Offline']
+
+const DEMO_DATA: Cluster[] = Array.from({ length: 40 }, (_unused, index) => ({
+  id: index + 1,
+  name: `cluster-${index + 1}`,
+  region: REGIONS[index % REGIONS.length],
+  status: STATUSES[index % STATUSES.length]
+}))
+
+const DEMO_COLUMNS = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'region', header: 'Region' },
+  { accessorKey: 'status', header: 'Status' }
+]
+
+const DRAWER_DEFAULT_WIDTH = 340
+const DRAWER_MIN_WIDTH = 220
+const DRAWER_MAX_WIDTH = 600
+
+const CONTAINER_STYLE = {
+  padding: 24,
+  background: 'var(--bg-secondary)',
+  height: 520
+}
+
+export function TableWithDrawerDemo() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [drawerWidth, setDrawerWidth] = useState(DRAWER_DEFAULT_WIDTH)
+  const [isResizing, setIsResizing] = useState(false)
+  const [selectedRow, setSelectedRow] = useState<Cluster | null>(null)
+
+  const handleRowClick = useCallback((row: Cluster) => {
+    setSelectedRow(row)
+    setIsOpen(true)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  const handleResizeStart = useCallback(
+    (e: MouseEvent) => {
+      setIsResizing(true)
+      const startX = e.clientX
+      const startWidth = drawerWidth
+
+      const onMouseMove = (moveEvent: globalThis.MouseEvent) => {
+        const delta = startX - moveEvent.clientX
+        const newWidth = Math.min(
+          DRAWER_MAX_WIDTH,
+          Math.max(DRAWER_MIN_WIDTH, startWidth + delta)
+        )
+        setDrawerWidth(newWidth)
+      }
+
+      const onMouseUp = () => {
+        setIsResizing(false)
+        window.removeEventListener('mousemove', onMouseMove)
+        window.removeEventListener('mouseup', onMouseUp)
+      }
+
+      window.addEventListener('mousemove', onMouseMove)
+      window.addEventListener('mouseup', onMouseUp)
+    },
+    [drawerWidth]
+  )
+
+  return (
+    <div style={CONTAINER_STYLE}>
+      <Table
+        columns={DEMO_COLUMNS}
+        data={DEMO_DATA}
+        drawerOpen={isOpen}
+        drawerWidth={drawerWidth}
+        onRowClick={handleRowClick}
+        showSearch
+        title='Click a row to open the drawer (toolbar stays full-width)'
+        drawer={
+          <TableDrawer
+            isOpen={isOpen}
+            isResizing={isResizing}
+            onClose={handleClose}
+            onResizeStart={handleResizeStart}
+            title={selectedRow ? `Details: ${selectedRow.name}` : 'Details'}
+            width={drawerWidth}
+          >
+            {selectedRow ? (
+              <div>
+                <p>
+                  <strong>Name:</strong> {selectedRow.name}
+                </p>
+                <p>
+                  <strong>Region:</strong> {selectedRow.region}
+                </p>
+                <p>
+                  <strong>Status:</strong> {selectedRow.status}
+                </p>
+              </div>
+            ) : null}
+          </TableDrawer>
+        }
+      />
+    </div>
+  )
+}

--- a/lib/v2/components/Table/Table/hooks/useTableOptions.ts
+++ b/lib/v2/components/Table/Table/hooks/useTableOptions.ts
@@ -15,6 +15,8 @@ import {
   getSortedRowModel
 } from '@tanstack/react-table'
 
+import { DefaultCell } from '../../DefaultCell'
+
 const DEFAULT_COLUMN_SIZE = 150
 const MIN_COLUMN_SIZE = 50
 const MAX_COLUMN_SIZE = 500
@@ -78,7 +80,8 @@ export function useTableOptions<TData>({
       defaultColumn: {
         size: DEFAULT_COLUMN_SIZE,
         minSize: MIN_COLUMN_SIZE,
-        maxSize: MAX_COLUMN_SIZE
+        maxSize: MAX_COLUMN_SIZE,
+        cell: DefaultCell as ColumnDef<TData>['cell']
       },
       getCoreRowModel: getCoreRowModel(),
       ...(manualSorting ? {} : { getSortedRowModel: getSortedRowModel() }),

--- a/lib/v2/components/Table/Table/table.module.scss
+++ b/lib/v2/components/Table/Table/table.module.scss
@@ -103,6 +103,7 @@
   overflow: auto hidden;
   flex-shrink: 0;
   background-color: var(--gray-100-900);
+  box-sizing: border-box;
 
   &::-webkit-scrollbar {
     display: none;
@@ -178,6 +179,10 @@ thead.tableHeader {
   box-sizing: border-box;
 
   &:last-child {
+    border-right: none;
+  }
+
+   &:has(+ .stickyActions) {
     border-right: none;
   }
 }
@@ -303,6 +308,69 @@ thead.tableHeader {
   box-sizing: border-box;
 }
 
+.tableCell.stickyActions {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.stickyActions {
+  position: sticky;
+  right: 0;
+  z-index: 3;
+
+  border-left: 1px solid var(--gray-300-700);
+  box-shadow: -2px 0 4px -1px var(--gray-300-700);
+
+  thead & {
+    background-color: var(--gray-100-900);
+  }
+
+  tbody tr.evenRow & {
+    background-color: var(--gray-0-1000);
+  }
+
+  tbody tr.oddRow & {
+    background-color: var(--gray-50-920);
+  }
+
+  tbody tr.activeRow & {
+    background-color: var(--purple-100-800) !important;
+  }
+
+  tbody tr.clickable:hover:not(.activeRow) & {
+    background-color: var(--gray-100-900) !important;
+  }
+}
+
+.stickyFirst {
+  position: sticky;
+  left: 0;
+  z-index: 3;
+
+  border-right: 1px solid var(--gray-300-700);
+  box-shadow: 2px 0 4px -1px var(--gray-300-700);
+
+  thead & {
+    background-color: var(--gray-100-900);
+  }
+
+  tbody tr.evenRow & {
+    background-color: var(--gray-0-1000);
+  }
+
+  tbody tr.oddRow & {
+    background-color: var(--gray-50-920);
+  }
+
+  tbody tr.activeRow & {
+    background-color: var(--purple-100-800) !important;
+  }
+
+  tbody tr.clickable:hover:not(.activeRow) & {
+    background-color: var(--gray-100-900) !important;
+  }
+}
+
 .emptyState {
   text-align: center;
   padding: 80px 16px;
@@ -342,4 +410,24 @@ thead.tableHeader {
 .customTitle {
   display: flex;
   align-items: center;
+}
+
+.tableBodyArea {
+  position: relative;
+  flex: 1;
+  display: flex;
+  min-height: 0;
+
+  margin-top: 16px;
+  border-radius: 4px;
+
+  background-color: var(--gray-50-950);
+}
+
+.tableBodyMain {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-self: flex-start;
 }

--- a/lib/v2/components/TableDrawer/tableDrawer.module.scss
+++ b/lib/v2/components/TableDrawer/tableDrawer.module.scss
@@ -7,6 +7,7 @@
   bottom: 0;
   min-width: 300px;
   border-radius: 4px;
+  box-sizing: border-box;
   background: var(--gray-100-900);
   border: 1px solid var(--gray-300-700);
   box-shadow: 0 2px 8px rgb(0 0 0 / 10%);

--- a/lib/v2/components/Tooltip/Tooltip.tsx
+++ b/lib/v2/components/Tooltip/Tooltip.tsx
@@ -118,7 +118,7 @@ export function Tooltip({
         title={data}
         classes={{
           tooltip: classes,
-          popper: extraPopperClass
+          popper: clsx(styles.popper, extraPopperClass)
         }}
         {...(popperProps && { PopperProps: popperProps })}
         {...(typeof data === 'string' && { 'aria-label': data })}

--- a/lib/v2/components/Tooltip/Tooltip.tsx
+++ b/lib/v2/components/Tooltip/Tooltip.tsx
@@ -145,7 +145,7 @@ export function Tooltip({
       title={tooltipContent}
       classes={{
         tooltip: classes,
-        popper: extraPopperClass
+        popper: clsx(styles.popper, extraPopperClass)
       }}
       {...(popperProps && { PopperProps: popperProps })}
       {...(typeof tooltipContent === 'string' && {

--- a/lib/v2/components/Tooltip/tooltip.module.scss
+++ b/lib/v2/components/Tooltip/tooltip.module.scss
@@ -31,3 +31,7 @@
 .tooltipChildWrapper {
   display: inline-flex;
 }
+
+.popper {
+  z-index: 2200;
+}

--- a/lib/v2/components/index.ts
+++ b/lib/v2/components/index.ts
@@ -187,6 +187,8 @@ export type {
   BooleanIconCellValue
 } from './Table/BooleanIconCell'
 export { BooleanIconCell } from './Table/BooleanIconCell'
+export type { CapabilitiesCellProps } from './Table/CapabilitiesCell'
+export { CapabilitiesCell } from './Table/CapabilitiesCell'
 export type { CapacityCellProps } from './Table/CapacityCell'
 export { CapacityCell } from './Table/CapacityCell'
 export type {


### PR DESCRIPTION
## Summary
v2 Table component enhancements to support the NeuralMesh FileSystems / Snapshots pages.

- **Table drawer slot** — Table accepts a `drawer` slot (+ `drawerOpen`/`drawerWidth`); the toolbar stays full-width while the drawer opens beside the rows.
- **Column pinning** — `pinFirstColumn` pins the first column left; the actions column stays pinned right.
- **Horizontal scroll** — wide tables scroll horizontally with the sticky actions column intact.
- **New `CapabilitiesCell`** cell component.
- **Cell refinements** — `CapacityCell`, `DefaultCell`, `RowActionsCell`.
- **Minor styling** — `Popup`, `Tooltip`, `MenuPopover`, `CapacityProgressBar`, `TableDrawer`.

## Stories
- `WithDrawerSlot` (backed by `TableWithDrawerDemo`)
- `WithRowActionsAndHorizontalScroll`
- `WithPinFirstColumn`

## Tests
Updated/added unit tests for Table, CapacityCell, DefaultCell, RowActionsCell, MenuPopover, and CapabilitiesCell.

Jira: WEKAPP-635082

🤖 Generated with [Claude Code](https://claude.com/claude-code)