### PR TITLE
fix(theme): suppress transitions during light/dark switch to remove the lag (WEKAPP-635082)

### DIFF
--- a/lib/context/darkModeContext.tsx
+++ b/lib/context/darkModeContext.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from 'react'
 
@@ -69,6 +70,8 @@ function DarkModeProvider(props: Readonly<PropsWithChildren>) {
     }
   })
 
+  const themeSwitchRafRef = useRef(0)
+
   const applyTheme = useCallback((newTheme: Theme) => {
     setThemeState(newTheme)
     const root = document.documentElement
@@ -80,8 +83,9 @@ function DarkModeProvider(props: Readonly<PropsWithChildren>) {
       document.body.classList.remove(themeClasses.dark)
       document.body.classList.add(themeClasses.light)
     }
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
+    window.cancelAnimationFrame(themeSwitchRafRef.current)
+    themeSwitchRafRef.current = window.requestAnimationFrame(() => {
+      themeSwitchRafRef.current = window.requestAnimationFrame(() => {
         root.classList.remove(THEME_SWITCHING_CLASS)
       })
     })

--- a/lib/context/darkModeContext.tsx
+++ b/lib/context/darkModeContext.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react'
 
-import React, {
+import {
   createContext,
   useCallback,
   useContext,
@@ -8,6 +8,7 @@ import React, {
   useMemo,
   useState
 } from 'react'
+
 import { LOCAL_STORAGE_UPDATE_EVENT } from '#consts'
 
 type Theme = {
@@ -20,6 +21,8 @@ const themeClasses = {
   dark: 'dark-mode'
 } as const
 
+const THEME_SWITCHING_CLASS = 'v2-theme-switching'
+
 const STORAGE_KEY = 'isDarkMode'
 const PREFERS_DARK = '(prefers-color-scheme: dark)'
 
@@ -31,7 +34,7 @@ const DarkModeContext = createContext<{
   setTheme: (theme: { isDarkMode: boolean } | { isSystem: true }) => void
 } | null>(null)
 
-function DarkModeProvider(props: PropsWithChildren) {
+function DarkModeProvider(props: Readonly<PropsWithChildren>) {
   const [themeState, setThemeState] = useState<Theme>(() => {
     const savedDarkMode = localStorage.getItem(STORAGE_KEY) as
       | 'true'
@@ -57,17 +60,19 @@ function DarkModeProvider(props: PropsWithChildren) {
         isDarkMode: true,
         isSystem: true
       }
-    }
-
-    document.body.classList.add(themeClasses.light)
-    return {
-      isDarkMode: false,
-      isSystem: true
+    } else {
+      document.body.classList.add(themeClasses.light)
+      return {
+        isDarkMode: false,
+        isSystem: true
+      }
     }
   })
 
   const applyTheme = useCallback((newTheme: Theme) => {
     setThemeState(newTheme)
+    const root = document.documentElement
+    root.classList.add(THEME_SWITCHING_CLASS)
     if (newTheme.isDarkMode) {
       document.body.classList.add(themeClasses.dark)
       document.body.classList.remove(themeClasses.light)
@@ -75,6 +80,11 @@ function DarkModeProvider(props: PropsWithChildren) {
       document.body.classList.remove(themeClasses.dark)
       document.body.classList.add(themeClasses.light)
     }
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        root.classList.remove(THEME_SWITCHING_CLASS)
+      })
+    })
   }, [])
 
   const setTheme = useCallback(

--- a/lib/v2/styles/index.scss
+++ b/lib/v2/styles/index.scss
@@ -62,3 +62,8 @@ body.light-mode {
 body.dark-mode {
   @include theme.v2-dark-theme;
 }
+
+.v2-theme-switching,
+.v2-theme-switching * {
+  transition: none !important;
+}


### PR DESCRIPTION
## Problem
Toggling light/dark flips all theme CSS vars at once, but elements with a `color`/`background` transition — v2 table rows (`background-color`), sortable headers (`color`), `IconButton`, scrollbars, the column resizer — then **animate** across the change. The result is a visible "sweep"/delay on every theme switch.

(Observe avoided this by not transitioning theme-driven colors; the v2 Table intentionally has hover transitions, and pure CSS can't tell a hover bg-change from a theme var-change — so both animate.)

## Fix
`DarkModeProvider` now adds a `v2-theme-switching` class to `<html>` for the swap frame and removes it after a double `requestAnimationFrame`. A global rule kills transitions while that class is present:

```scss
.v2-theme-switching,
.v2-theme-switching * { transition: none !important; }
```

So theme vars apply **instantly** during the toggle, while hover/other transitions stay smooth the rest of the time. Works for every consumer (no per-component changes).

Also cleared pre-existing lint in the touched `darkModeContext.tsx` (default React import → named, read-only props, elseif-without-else, import order).

## Test
- eslint clean on `darkModeContext.tsx`; stylelint clean on `lib/v2/styles/index.scss` (camelCase warnings are the pre-existing kebab theme-class names).
- Manual: toggle theme on a table-heavy page — rows/headers/icons switch instantly, no sweep.

Jira: WEKAPP-635082

🤖 Generated with [Claude Code](https://claude.com/claude-code)