### PR TITLE
fix(Table): direct pixel column widths with 1:1 resize (WEKAPP-635082)

### DIFF
--- a/lib/v2/components/Table/Table/Table.test.tsx
+++ b/lib/v2/components/Table/Table/Table.test.tsx
@@ -34,7 +34,6 @@ const FILTERABLE_COLUMNS: ColumnDef<Item>[] = [
   }
 ]
 
-const SPLIT_TABLE_COUNT = 2
 const RESIZER_ID_TESTID = 'column-resizer-id'
 const RESIZER_NAME_TESTID = 'column-resizer-name'
 const ROW_ACTIONS_BUTTON_TESTID = 'row-actions-button'
@@ -165,7 +164,7 @@ describe('Table', () => {
       expect(screen.queryByTestId(RESIZER_NAME_TESTID)).toBeInTheDocument()
     })
 
-    it('keeps the header and body tables on the same width floor and column count', async () => {
+    it('synchronizes header and body cell widths', async () => {
       const { container } = render(
         <Table
           columns={COLUMNS}
@@ -175,15 +174,25 @@ describe('Table', () => {
       )
 
       await waitFor(() => {
-        const tables = Array.from(container.querySelectorAll('table'))
-        expect(tables.length).toBe(SPLIT_TABLE_COUNT)
-        const [headerTable, bodyTable] = tables
-        expect(headerTable.style.minWidth).toBeTruthy()
-        expect(headerTable.style.minWidth).toBe(bodyTable.style.minWidth)
+        const headerRow = container.querySelector('thead tr')
+        const bodyRows = container.querySelectorAll('tbody tr')
+        expect(headerRow).toBeTruthy()
+        expect(bodyRows.length).toBeGreaterThan(0)
 
-        const headerCells = container.querySelectorAll('thead tr th')
-        const bodyCells = container.querySelectorAll('tbody tr:first-child td')
+        const headerCells = Array.from(headerRow?.querySelectorAll('th') ?? [])
+        const bodyCells = Array.from(bodyRows[0].querySelectorAll('td'))
         expect(headerCells.length).toBe(bodyCells.length)
+
+        headerCells.forEach((headerCell, index) => {
+          const headerWidth = headerCell
+            .getAttribute('style')
+            ?.match(/width:\s*(\d+(?:\.\d+)?px)/)?.[1]
+          const bodyWidth = bodyCells[index]
+            .getAttribute('style')
+            ?.match(/width:\s*(\d+(?:\.\d+)?px)/)?.[1]
+          expect(headerWidth).toBeTruthy()
+          expect(headerWidth).toBe(bodyWidth)
+        })
       })
     })
   })

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -2,7 +2,6 @@ import type { CustomFilters } from '../FilterPopover'
 import type { ActiveFilter } from '../filterUtils'
 import type { RowAction } from './rowActions'
 import type {
-  Column,
   ColumnDef,
   ColumnFiltersState,
   ColumnResizeMode,
@@ -23,11 +22,7 @@ import { NOOP } from '#v2/utils/consts'
 import { Pagination } from '../Pagination'
 import { RowActionsCell } from '../RowActionsCell'
 import { TableFilter } from '../TableFilter'
-import {
-  buildTableColumns,
-  getCanShowFilter,
-  getColumnWidth
-} from '../tableUtils'
+import { buildTableColumns, getCanShowFilter } from '../tableUtils'
 import { useColumnVisibility } from './hooks/useColumnVisibility'
 import { useGlobalSearch } from './hooks/useGlobalSearch'
 import { useInitialSorting } from './hooks/useInitialSorting'
@@ -402,22 +397,6 @@ export function Table<TData = unknown>({
         .find((col) => col.id !== ROW_ACTIONS_COLUMN_ID)?.id
     : undefined
 
-  const visibleLeafColumns = table.getVisibleLeafColumns()
-  const reservedWidth = visibleLeafColumns
-    .filter((col) => col.id === ROW_ACTIONS_COLUMN_ID)
-    .reduce((sum, col) => sum + col.getSize(), 0)
-  const proportionalTotal = visibleLeafColumns
-    .filter((col) => col.id !== ROW_ACTIONS_COLUMN_ID)
-    .reduce((sum, col) => sum + col.getSize(), 0)
-  const totalColumnsWidth = reservedWidth + proportionalTotal
-
-  const columnWidth = (column: Column<TData, unknown>) =>
-    getColumnWidth(column, {
-      actionsColumnId: ROW_ACTIONS_COLUMN_ID,
-      reservedWidth,
-      proportionalTotal
-    })
-
   const wrapperStyle = maxHeight
     ? {
         maxHeight: typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight
@@ -511,10 +490,7 @@ export function Table<TData = unknown>({
               ref={headerRef}
               className={styles.tableHeaderWrapper}
             >
-              <table
-                className={styles.table}
-                style={{ minWidth: totalColumnsWidth }}
-              >
+              <table className={styles.table}>
                 <thead className={styles.tableHeader}>
                   {table.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id}>
@@ -530,7 +506,7 @@ export function Table<TData = unknown>({
                             <th
                               key={header.id}
                               data-testid={`column-header-${columnId}`}
-                              style={{ width: columnWidth(header.column) }}
+                              style={{ width: header.getSize() }}
                               className={clsx(styles.headerCell, {
                                 [styles.stickyActions]: isActionsColumn,
                                 [styles.stickyFirst]: isFirstColumn
@@ -594,7 +570,6 @@ export function Table<TData = unknown>({
               <table
                 className={styles.table}
                 data-testid={dataTestId}
-                style={{ minWidth: totalColumnsWidth }}
               >
                 <tbody className={styles.tableBody}>
                   <TableContent
@@ -611,7 +586,7 @@ export function Table<TData = unknown>({
                       const isActionsCell =
                         cell.column.id === ROW_ACTIONS_COLUMN_ID
                       const isFirstCell = cell.column.id === firstDataColumnId
-                      const cellWidth = columnWidth(cell.column)
+                      const cellWidth = cell.column.getSize()
 
                       return (
                         <td

--- a/lib/v2/components/Table/tableUtils.test.ts
+++ b/lib/v2/components/Table/tableUtils.test.ts
@@ -8,7 +8,6 @@ import {
   buildTableColumns,
   extractColumnIds,
   getCanShowFilter,
-  getColumnWidth,
   isSortableColumn
 } from './tableUtils'
 
@@ -120,42 +119,3 @@ describe('getCanShowFilter', () => {
   })
 })
 
-describe('getColumnWidth', () => {
-  const ACTIONS_ID = '__rowActions__'
-  const ACTIONS_WIDTH = 40
-  const NAME_SIZE = 200
-  const VALUE_SIZE = 100
-  const PROPORTIONAL_TOTAL = 300
-
-  const makeCol = (id: string, size: number) =>
-    ({ id, getSize: () => size } as unknown as Parameters<
-      typeof getColumnWidth
-    >[0])
-
-  const ctx = {
-    actionsColumnId: ACTIONS_ID,
-    reservedWidth: ACTIONS_WIDTH,
-    proportionalTotal: PROPORTIONAL_TOTAL
-  }
-
-  it('keeps the actions column at its fixed pixel size', () => {
-    expect(getColumnWidth(makeCol(ACTIONS_ID, ACTIONS_WIDTH), ctx)).toBe(
-      ACTIONS_WIDTH
-    )
-  })
-
-  it('gives each data column a proportional share of the space left after the reserved width', () => {
-    expect(getColumnWidth(makeCol('name', NAME_SIZE), ctx)).toBe(
-      'calc((100% - 40px) * 0.666667)'
-    )
-    expect(getColumnWidth(makeCol('value', VALUE_SIZE), ctx)).toBe(
-      'calc((100% - 40px) * 0.333333)'
-    )
-  })
-
-  it('falls back to the raw size when there are no proportional columns', () => {
-    expect(
-      getColumnWidth(makeCol('name', NAME_SIZE), { ...ctx, proportionalTotal: 0 })
-    ).toBe(NAME_SIZE)
-  })
-})

--- a/lib/v2/components/Table/tableUtils.ts
+++ b/lib/v2/components/Table/tableUtils.ts
@@ -1,44 +1,9 @@
 import type { ColumnWithHeader } from './filterUtils'
-import type { Column, ColumnDef, Header } from '@tanstack/react-table'
+import type { ColumnDef, Header } from '@tanstack/react-table'
 
 import { FILTER_TYPES } from '#v2/utils/consts'
 
 import { getColumnId as getGenericColumnId } from './filterUtils'
-
-/** Decimal places kept when serializing a column's proportional share. */
-const PROPORTION_PRECISION = 6
-
-export interface ColumnWidthContext {
-  /** Id of the row-actions column, which stays at its fixed pixel size. */
-  actionsColumnId: string
-  /** Total pixel width of the fixed (non-proportional) columns. */
-  reservedWidth: number
-  /** Sum of the sizes of the proportional (data) columns. */
-  proportionalTotal: number
-}
-
-/**
- * Width for a column so the table fills its container *without* stretching the
- * row-actions column: the actions column keeps its fixed pixel size, and every
- * other (data) column gets a share of the remaining width proportional to its
- * own size.
- *
- * `100%` resolves against the table width, which is floored at the columns'
- * combined size (via the table's `min-width`), so the calc result is never
- * smaller than the column's own size — on a narrow viewport columns keep their
- * size and the table scrolls horizontally instead of collapsing.
- */
-export function getColumnWidth<TData>(
-  column: Column<TData, unknown>,
-  { actionsColumnId, reservedWidth, proportionalTotal }: ColumnWidthContext
-): string | number {
-  const size = column.getSize()
-  if (column.id === actionsColumnId || proportionalTotal <= 0) {
-    return size
-  }
-  const proportion = (size / proportionalTotal).toFixed(PROPORTION_PRECISION)
-  return `calc((100% - ${reservedWidth}px) * ${proportion})`
-}
 
 /**
  * Resolves a column's id from a TanStack `ColumnDef` (id → accessorKey →


### PR DESCRIPTION
## Summary

Reverts the proportional `calc()` fill from #432. In practice the proportional model made a column's `size` a *relative weight* (not a width) and muted manual resize — so capacity/status columns couldn't be set or dragged to a specific width.

Back to **direct pixel widths**:
- a column's `size` is its actual pixel width
- drag-resize is **1:1**
- the table still fills wide screens via the browser's native proportional stretch (`table-layout: fixed; width: 100%`)

**Trade-off:** the row-actions column stretches a little on wide screens — it can't be pinned without giving up direct px widths + resize (the two are mutually exclusive in a fixed-layout table). The `framed` prop is unchanged.

## Changes

- Remove `getColumnWidth` / `ColumnWidthContext` from `tableUtils`.
- `Table.tsx` header `th` and body `td` widths use `getSize()` again; drop the `min-width` floor and the proportional computation.
- Restore the px header/body width-sync resizing test; drop the `getColumnWidth` unit tests.

## Tests

Full Table suite green (269 tests), 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)