### PR TITLE
feat(v2): IP inputs, Select enhancements, table fixes (v4.36.0)

### DIFF
--- a/lib/v2/components/Table/FilterPopover/filterPopover.module.scss
+++ b/lib/v2/components/Table/FilterPopover/filterPopover.module.scss
@@ -66,6 +66,7 @@
   user-select: none;
   font-size: 14px;
   font-weight: 700;
+  color: var(--text-color-primary);
 }
 
 .textFilterInput {

--- a/lib/v2/components/Table/Table/table.module.scss
+++ b/lib/v2/components/Table/Table/table.module.scss
@@ -77,6 +77,7 @@
 }
 
 .tableContainer {
+  flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -176,7 +177,7 @@ thead.tableHeader {
     border-right: none;
   }
 
-   &:has(+ .stickyActions) {
+  &:has(+ .stickyActions) {
     border-right: none;
   }
 }

--- a/lib/v2/components/Table/TableHeader/TableHeader.tsx
+++ b/lib/v2/components/Table/TableHeader/TableHeader.tsx
@@ -147,39 +147,20 @@ interface MenuPositionResult {
   fixedPosition: { top: number; right: number } | null
 }
 
-function hasContainerOverflowHidden(container: Element): boolean {
-  const styles = window.getComputedStyle(container)
-  return styles.overflow === 'hidden' || styles.overflowY === 'hidden'
-}
-
-function calculateMenuPosition(
-  buttonRect: DOMRect,
-  container: Element | null
-): MenuPositionResult {
-  const containerRect = container?.getBoundingClientRect()
-  const hasOverflow = container && hasContainerOverflowHidden(container)
-
-  if (hasOverflow && containerRect) {
-    const spaceBelow = containerRect.bottom - buttonRect.bottom
-    const spaceAbove = buttonRect.top - containerRect.top
-    const shouldShowAbove =
-      spaceBelow < SETTINGS_MENU_HEIGHT && spaceAbove > spaceBelow
-
-    const rightOffset = window.innerWidth - buttonRect.right
-    const topPosition = shouldShowAbove
-      ? buttonRect.top - SETTINGS_MENU_HEIGHT - SETTINGS_MENU_MARGIN
-      : buttonRect.bottom + SETTINGS_MENU_MARGIN
-
-    return {
-      shouldShowAbove,
-      fixedPosition: { top: topPosition, right: rightOffset }
-    }
-  }
-
+function calculateMenuPosition(buttonRect: DOMRect): MenuPositionResult {
   const spaceBelow = window.innerHeight - buttonRect.bottom
+  const spaceAbove = buttonRect.top
+  const shouldShowAbove =
+    spaceBelow < SETTINGS_MENU_HEIGHT && spaceAbove > spaceBelow
+
+  const rightOffset = window.innerWidth - buttonRect.right
+  const topPosition = shouldShowAbove
+    ? buttonRect.top - SETTINGS_MENU_HEIGHT - SETTINGS_MENU_MARGIN
+    : buttonRect.bottom + SETTINGS_MENU_MARGIN
+
   return {
-    shouldShowAbove: spaceBelow < SETTINGS_MENU_HEIGHT,
-    fixedPosition: null
+    shouldShowAbove,
+    fixedPosition: { top: topPosition, right: rightOffset }
   }
 }
 
@@ -213,6 +194,7 @@ export function TableHeader({
     right: number
   } | null>(null)
   const settingsButtonRef = useRef<HTMLButtonElement>(null)
+  const settingsMenuRef = useRef<HTMLDivElement>(null)
   const [immediateState, setImmediateState] = useState<Record<string, boolean>>(
     {}
   )
@@ -225,6 +207,20 @@ export function TableHeader({
     const timeoutId = setTimeout(forceUpdate, VISIBILITY_STATE_SYNC_DELAY)
     return () => clearTimeout(timeoutId)
   }, [activeFilters])
+
+  useEffect(() => {
+    if (!showSettingsMenu) {
+      return undefined
+    }
+    const closeOnScroll = (event: Event) => {
+      if (settingsMenuRef.current?.contains(event.target as Node)) {
+        return
+      }
+      setShowSettingsMenu(false)
+    }
+    window.addEventListener('scroll', closeOnScroll, true)
+    return () => window.removeEventListener('scroll', closeOnScroll, true)
+  }, [showSettingsMenu])
 
   const getDisplayCount = useCallback(() => {
     let displayCount = count
@@ -381,13 +377,8 @@ export function TableHeader({
   const toggleSettingsMenu = () => {
     if (!showSettingsMenu && settingsButtonRef.current) {
       const buttonRect = settingsButtonRef.current.getBoundingClientRect()
-      const container = settingsButtonRef.current.closest(
-        '[class*="subTabContent"], [class*="tableContent"], [class*="tableWrapper"], [class*="container"]'
-      )
-      const { shouldShowAbove, fixedPosition } = calculateMenuPosition(
-        buttonRect,
-        container
-      )
+      const { shouldShowAbove, fixedPosition } =
+        calculateMenuPosition(buttonRect)
       setMenuPositionAbove(shouldShowAbove)
       setMenuPosition(fixedPosition)
     }
@@ -494,6 +485,7 @@ export function TableHeader({
 
     return (
       <div
+        ref={settingsMenuRef}
         data-testid='table-settings-menu'
         style={menuStyle}
         className={clsx(

--- a/lib/v2/components/index.ts
+++ b/lib/v2/components/index.ts
@@ -111,6 +111,10 @@ export type { HealthStatusProps } from './HealthStatus'
 export { HealthStatus } from './HealthStatus'
 export type { IconButtonProps } from './IconButton'
 export { IconButton } from './IconButton'
+export type { IpInputProps } from './inputs/IpInput'
+export { IpInput } from './inputs/IpInput'
+export type { IpRangeInputProps } from './inputs/IpRangeInput'
+export { IpRangeInput } from './inputs/IpRangeInput'
 export type { MultiSelectAutocompleteProps } from './inputs/MultiSelectAutocomplete'
 export { MultiSelectAutocomplete } from './inputs/MultiSelectAutocomplete'
 export type { NumberInputProps } from './inputs/NumberInput'
@@ -122,7 +126,11 @@ export type {
   RadioValue
 } from './inputs/RadioGroup'
 export { RADIO_GROUP_DIRECTIONS, RadioGroup } from './inputs/RadioGroup'
-export type { SelectOption, SelectProps } from './inputs/Select'
+export type {
+  SelectOption,
+  SelectOptionValue,
+  SelectProps
+} from './inputs/Select'
 export { Select } from './inputs/Select'
 export type { TextAreaProps } from './inputs/TextArea'
 export { TextArea } from './inputs/TextArea'
@@ -317,7 +325,7 @@ export {
 export type { TableDrawerProps } from './TableDrawer'
 export { TableDrawer } from './TableDrawer'
 export type { ScrollDirection, Tab, TabsProps, TabVariant } from './Tabs'
-export { SCROLL_DIRECTIONS, TAB_VARIANTS,Tabs } from './Tabs'
+export { SCROLL_DIRECTIONS, TAB_VARIANTS, Tabs } from './Tabs'
 export type { TooltipProps } from './Tooltip'
 export { Tooltip } from './Tooltip'
 export {

--- a/lib/v2/components/inputs/IpInput/IpInput.stories.tsx
+++ b/lib/v2/components/inputs/IpInput/IpInput.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { useState } from 'react'
+
+import { EMPTY_STRING, NOOP } from '#v2/utils/consts'
+
+import { IpInput } from './IpInput'
+
+import storiesStyles from './ipInputStories.module.scss'
+
+const meta: Meta<typeof IpInput> = {
+  title: 'v2/Inputs/IpInput',
+  component: IpInput,
+  tags: ['autodocs']
+}
+
+export default meta
+type Story = StoryObj<typeof IpInput>
+
+// eslint-disable-next-line sonarjs/no-hardcoded-ip
+const EXAMPLE_IP = '192.168.1.1'
+// eslint-disable-next-line sonarjs/no-hardcoded-ip
+const DISABLED_EXAMPLE_IP = '10.0.0.1'
+
+function ControlledIpInput({
+  initialValue = EMPTY_STRING
+}: Readonly<{ initialValue?: string }>) {
+  const [value, setValue] = useState(initialValue)
+  return (
+    <div className={storiesStyles.container}>
+      <IpInput
+        label='IP Address'
+        onChange={setValue}
+        required
+        value={value}
+      />
+      <p className={storiesStyles.valueDisplay}>
+        Value: {JSON.stringify(value)}
+      </p>
+    </div>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <ControlledIpInput initialValue={EXAMPLE_IP} />
+}
+
+export const WithError: Story = {
+  render: () => (
+    <div className={storiesStyles.container}>
+      <IpInput
+        error='Invalid IP address'
+        label='IP Address'
+        onChange={NOOP}
+        required
+        value={EMPTY_STRING}
+      />
+    </div>
+  )
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <div className={storiesStyles.container}>
+      <IpInput
+        disabled
+        label='IP Address'
+        onChange={NOOP}
+        value={DISABLED_EXAMPLE_IP}
+      />
+    </div>
+  )
+}

--- a/lib/v2/components/inputs/IpInput/IpInput.test.tsx
+++ b/lib/v2/components/inputs/IpInput/IpInput.test.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EMPTY_STRING } from '#v2/utils/consts'
+
+import { IpInput } from './IpInput'
+
+const OCTET_INPUT_COUNT = 4
+
+// Test IPs — safe to hardcode in test files (sonarjs/no-hardcoded-ip)
+// eslint-disable-next-line sonarjs/no-hardcoded-ip
+const IP_BASIC = '192.168.1.1'
+// eslint-disable-next-line sonarjs/no-hardcoded-ip
+const IP_MULTI_OCTET = '10.20.30.40'
+// eslint-disable-next-line sonarjs/no-hardcoded-ip
+const IP_SIMPLE = '10.0.0.1'
+// eslint-disable-next-line sonarjs/no-hardcoded-ip
+const IP_PASTE = '1.2.3.4'
+// eslint-disable-next-line sonarjs/no-hardcoded-ip
+const IP_CLAMPED = '255.0.0.1'
+// eslint-disable-next-line sonarjs/no-hardcoded-ip
+const IP_CHANGED = '192.0.0.1'
+
+const OCTET_10 = 10
+const OCTET_20 = 20
+const OCTET_30 = 30
+const OCTET_40 = 40
+const OCTET_192 = 192
+const OCTET_1 = 1
+const OCTET_2 = 2
+const OCTET_3 = 3
+const OCTET_4_VAL = 4
+const OCTET_255 = 255
+const OCTET_5 = 5
+
+describe('IpInput', () => {
+  it('renders 4 number inputs', () => {
+    render(
+      <IpInput
+        onChange={vi.fn()}
+        value={IP_BASIC}
+      />
+    )
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(OCTET_INPUT_COUNT)
+  })
+
+  it('displays the correct octet values', () => {
+    render(
+      <IpInput
+        onChange={vi.fn()}
+        value={IP_MULTI_OCTET}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    expect(inputs[0]).toHaveValue(OCTET_10)
+    expect(inputs[1]).toHaveValue(OCTET_20)
+    expect(inputs[2]).toHaveValue(OCTET_30)
+    expect(inputs[3]).toHaveValue(OCTET_40)
+  })
+
+  it('calls onChange with joined IP when an octet changes', () => {
+    const onChange = vi.fn()
+    render(
+      <IpInput
+        onChange={onChange}
+        value={IP_SIMPLE}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: String(OCTET_192) } })
+    expect(onChange).toHaveBeenCalledWith(IP_CHANGED)
+  })
+
+  it('emits EMPTY_STRING when required=true and one octet is blank', () => {
+    const onChange = vi.fn()
+    render(
+      <IpInput
+        onChange={onChange}
+        required
+        value={IP_SIMPLE}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[2], { target: { value: EMPTY_STRING } })
+    expect(onChange).toHaveBeenCalledWith(EMPTY_STRING)
+  })
+
+  it('clamps octet value to 0–255', () => {
+    const onChange = vi.fn()
+    render(
+      <IpInput
+        onChange={onChange}
+        value={IP_SIMPLE}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '300' } })
+    expect(onChange).toHaveBeenCalledWith(IP_CLAMPED)
+  })
+
+  it('distributes a valid pasted IP across all octets', () => {
+    const onChange = vi.fn()
+    render(
+      <IpInput
+        onChange={onChange}
+        value={EMPTY_STRING}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.paste(inputs[0], {
+      clipboardData: { getData: () => IP_PASTE }
+    })
+    expect(onChange).toHaveBeenCalledWith(IP_PASTE)
+  })
+
+  it('shows the label when provided', () => {
+    render(
+      <IpInput
+        label='Test Label'
+        onChange={vi.fn()}
+        value={EMPTY_STRING}
+      />
+    )
+    expect(screen.getByText('Test Label')).toBeInTheDocument()
+  })
+
+  it('shows the required star when required=true', () => {
+    render(
+      <IpInput
+        label='IP'
+        onChange={vi.fn()}
+        required
+        value={EMPTY_STRING}
+      />
+    )
+    expect(screen.getByText('*')).toBeInTheDocument()
+  })
+
+  it('renders disabled inputs when disabled=true', () => {
+    render(
+      <IpInput
+        disabled
+        onChange={vi.fn()}
+        value={IP_PASTE}
+      />
+    )
+    screen.getAllByRole('spinbutton').forEach((input) => {
+      expect(input).toBeDisabled()
+    })
+  })
+
+  it('octet values are correct after paste', () => {
+    const onChange = vi.fn()
+    render(
+      <IpInput
+        onChange={onChange}
+        value={EMPTY_STRING}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.paste(inputs[0], {
+      clipboardData: { getData: () => IP_PASTE }
+    })
+    expect(onChange).toHaveBeenCalledWith(
+      `${OCTET_1}.${OCTET_2}.${OCTET_3}.${OCTET_4_VAL}`
+    )
+  })
+
+  it('does not advance focus or auto-advance for low octet values', () => {
+    const onChange = vi.fn()
+    render(
+      <IpInput
+        onChange={onChange}
+        value={IP_SIMPLE}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: String(OCTET_5) } })
+    expect(onChange).toHaveBeenCalledWith(`${OCTET_5}.${0}.${0}.${OCTET_1}`)
+  })
+
+  it('clamps to max 255 correctly', () => {
+    const onChange = vi.fn()
+    render(
+      <IpInput
+        onChange={onChange}
+        value={IP_SIMPLE}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: String(OCTET_255) } })
+    expect(onChange).toHaveBeenCalledWith(`${OCTET_255}.${0}.${0}.${OCTET_1}`)
+  })
+})

--- a/lib/v2/components/inputs/IpInput/IpInput.tsx
+++ b/lib/v2/components/inputs/IpInput/IpInput.tsx
@@ -1,0 +1,177 @@
+import type { ChangeEvent, ClipboardEvent, KeyboardEvent } from 'react'
+
+import { useRef, useState } from 'react'
+import clsx from 'clsx'
+
+import { EMPTY_STRING, KEYBOARD_KEYS } from '#v2/utils/consts'
+
+import styles from './ipInput.module.scss'
+
+const OCTET_COUNT = 4
+const MAX_OCTET = 255
+const MIN_OCTET = 0
+const AUTO_ADVANCE_THRESHOLD = 100
+const IP_PATTERN = /^(\d{1,3}\.){3}\d{1,3}$/
+const BLANK_OCTETS = [EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING]
+
+function parseOctets(value: string): string[] {
+  if (!value) {
+    return [...BLANK_OCTETS]
+  }
+  const parts = value.split('.')
+  if (parts.length === OCTET_COUNT) {
+    return parts
+  }
+  return [...BLANK_OCTETS]
+}
+
+function clampOctet(raw: string): string {
+  if (raw === EMPTY_STRING) {
+    return EMPTY_STRING
+  }
+  const num = parseInt(raw, 10)
+  if (Number.isNaN(num)) {
+    return EMPTY_STRING
+  }
+  return String(Math.min(MAX_OCTET, Math.max(MIN_OCTET, num)))
+}
+
+export interface IpInputProps {
+  value: string
+  onChange: (value: string) => void
+  label?: string
+  disabled?: boolean
+  required?: boolean
+  error?: string
+  info?: string
+  dataTestId?: string
+}
+
+export function IpInput({
+  value,
+  onChange,
+  label,
+  disabled = false,
+  required = false,
+  error,
+  dataTestId
+}: Readonly<IpInputProps>) {
+  const [octets, setOctets] = useState<string[]>(() => parseOctets(value))
+  const [lastValue, setLastValue] = useState(value)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  if (value !== lastValue) {
+    setLastValue(value)
+    setOctets(parseOctets(value))
+  }
+
+  function getInputs(): NodeListOf<HTMLInputElement> | null {
+    return (
+      containerRef.current?.querySelectorAll('input[type="number"]') ?? null
+    )
+  }
+
+  function focusNext(currentIndex: number) {
+    const inputs = getInputs()
+    if (inputs && currentIndex < inputs.length - 1) {
+      inputs[currentIndex + 1].focus()
+      inputs[currentIndex + 1].select()
+    }
+  }
+
+  function focusPrev(currentIndex: number) {
+    const inputs = getInputs()
+    if (inputs && currentIndex > 0) {
+      inputs[currentIndex - 1].focus()
+      inputs[currentIndex - 1].select()
+    }
+  }
+
+  function emitChange(nextOctets: string[]) {
+    const anyBlank = nextOctets.some((o) => o === EMPTY_STRING)
+    const nextValue = anyBlank ? EMPTY_STRING : nextOctets.join('.')
+    setLastValue(nextValue)
+    onChange(nextValue)
+  }
+
+  function handleOctetChange(index: number, e: ChangeEvent<HTMLInputElement>) {
+    const raw = e.target.value
+    const clamped = clampOctet(raw)
+    const next = octets.map((o, i) => (i === index ? clamped : o))
+    setOctets(next)
+    emitChange(next)
+
+    if (
+      clamped !== EMPTY_STRING &&
+      parseInt(clamped, 10) >= AUTO_ADVANCE_THRESHOLD
+    ) {
+      focusNext(index)
+    }
+  }
+
+  function handleKeyDown(index: number, e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === KEYBOARD_KEYS.ARROW_RIGHT || e.key === '.') {
+      e.preventDefault()
+      focusNext(index)
+    } else if (e.key === KEYBOARD_KEYS.ARROW_LEFT) {
+      e.preventDefault()
+      focusPrev(index)
+    } else {
+      // no-op for other keys
+    }
+  }
+
+  function handlePaste(e: ClipboardEvent<HTMLInputElement>) {
+    const pasted = e.clipboardData.getData('text')
+    if (IP_PATTERN.test(pasted)) {
+      e.preventDefault()
+      const parts = pasted.split('.')
+      const next = parts.map(clampOctet)
+      setOctets(next)
+      emitChange(next)
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={clsx(
+        styles.container,
+        error && styles.error,
+        disabled && styles.disabled
+      )}
+      {...(dataTestId && { 'data-testid': dataTestId })}
+    >
+      {label ? (
+        <span className={styles.label}>
+          {label}
+          {required ? <span className={styles.requiredStar}> *</span> : null}
+        </span>
+      ) : null}
+      <div className={styles.valueRow}>
+        {octets.map((octet, index) => (
+          <span
+            key={index}
+            className={styles.octetWrapper}
+          >
+            <input
+              className={styles.octetInput}
+              disabled={disabled}
+              max={MAX_OCTET}
+              min={MIN_OCTET}
+              onChange={(e) => handleOctetChange(index, e)}
+              onKeyDown={(e) => handleKeyDown(index, e)}
+              onPaste={handlePaste}
+              type='number'
+              value={octet}
+            />
+            {index < OCTET_COUNT - 1 ? (
+              <span className={styles.separator}>.</span>
+            ) : null}
+          </span>
+        ))}
+      </div>
+      {error ? <span className={styles.errorText}>{error}</span> : null}
+    </div>
+  )
+}

--- a/lib/v2/components/inputs/IpInput/index.ts
+++ b/lib/v2/components/inputs/IpInput/index.ts
@@ -1,0 +1,2 @@
+export type { IpInputProps } from './IpInput'
+export { IpInput } from './IpInput'

--- a/lib/v2/components/inputs/IpInput/ipInput.module.scss
+++ b/lib/v2/components/inputs/IpInput/ipInput.module.scss
@@ -1,0 +1,96 @@
+@use '../../../styles/colors' as *;
+
+.container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+  padding: 0 12px;
+  border: 1px solid var(--gray-350-650);
+  border-radius: 4px;
+  height: 36px;
+  background: var(--gray-50-920);
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:focus-within {
+    border-color: var(--purple-500);
+    box-shadow: 0 0 0 1px var(--purple-500);
+  }
+
+  &.error {
+    border-color: var(--red-500);
+
+    &:focus-within {
+      border-color: var(--red-500);
+      box-shadow: 0 0 0 1px var(--red-500);
+    }
+  }
+
+  &.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+}
+
+.label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--gray-600-400);
+  line-height: 1;
+  white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
+}
+
+.requiredStar {
+  color: var(--red-500);
+}
+
+.valueRow {
+  display: flex;
+  align-items: center;
+}
+
+.octetWrapper {
+  display: inline-flex;
+  align-items: center;
+}
+
+.octetInput {
+  background: transparent;
+  border: none;
+  outline: none;
+  width: 40px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--gray-950-20);
+  padding: 0;
+  appearance: textfield;
+  -moz-appearance: textfield;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}
+
+.separator {
+  font-size: 14px;
+  color: var(--gray-600-400);
+  user-select: none;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.errorText {
+  position: absolute;
+  bottom: -18px;
+  left: 4px;
+  font-size: 11px;
+  color: var(--red-500);
+  white-space: nowrap;
+}

--- a/lib/v2/components/inputs/IpInput/ipInputStories.module.scss
+++ b/lib/v2/components/inputs/IpInput/ipInputStories.module.scss
@@ -1,0 +1,11 @@
+@use '../../../styles/colors' as *;
+
+.container {
+  width: 240px;
+}
+
+.valueDisplay {
+  margin-top: 24px;
+  font-size: 12px;
+  color: var(--gray-700-300);
+}

--- a/lib/v2/components/inputs/IpRangeInput/IpRangeInput.stories.tsx
+++ b/lib/v2/components/inputs/IpRangeInput/IpRangeInput.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { useState } from 'react'
+
+import { EMPTY_STRING, NOOP } from '#v2/utils/consts'
+
+import { IpRangeInput } from './IpRangeInput'
+
+import storiesStyles from './ipRangeInputStories.module.scss'
+
+const meta: Meta<typeof IpRangeInput> = {
+  title: 'v2/Inputs/IpRangeInput',
+  component: IpRangeInput,
+  tags: ['autodocs']
+}
+
+export default meta
+type Story = StoryObj<typeof IpRangeInput>
+
+const EXAMPLE_RANGE = '192.168.1.1-192.168.1.100'
+const DISABLED_RANGE = '10.0.0.1-10.0.0.50'
+
+function ControlledIpRangeInput({
+  initialValue = EMPTY_STRING
+}: Readonly<{ initialValue?: string }>) {
+  const [value, setValue] = useState(initialValue)
+  return (
+    <div className={storiesStyles.container}>
+      <IpRangeInput
+        label='IP Range'
+        onChange={setValue}
+        required
+        value={value}
+      />
+      <p className={storiesStyles.valueDisplay}>
+        Value: {JSON.stringify(value)}
+      </p>
+    </div>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <ControlledIpRangeInput initialValue={EXAMPLE_RANGE} />
+}
+
+export const WithError: Story = {
+  render: () => (
+    <div className={storiesStyles.container}>
+      <IpRangeInput
+        error='IP range is required'
+        label='IP Range'
+        onChange={NOOP}
+        required
+        value={EMPTY_STRING}
+      />
+    </div>
+  )
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <div className={storiesStyles.container}>
+      <IpRangeInput
+        disabled
+        label='IP Range'
+        onChange={NOOP}
+        value={DISABLED_RANGE}
+      />
+    </div>
+  )
+}

--- a/lib/v2/components/inputs/IpRangeInput/IpRangeInput.test.tsx
+++ b/lib/v2/components/inputs/IpRangeInput/IpRangeInput.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EMPTY_STRING } from '#v2/utils/consts'
+
+import { IpRangeInput } from './IpRangeInput'
+
+const TOTAL_OCTET_INPUTS = 8
+
+const RANGE_BASIC = '10.0.0.1-10.0.0.50'
+const RANGE_DETAILED = '192.168.1.1-192.168.1.100'
+
+const OCTET_192 = 192
+const OCTET_168 = 168
+const OCTET_1 = 1
+const OCTET_100 = 100
+const OCTET_5 = 5
+const OCTET_99 = 99
+
+describe('IpRangeInput', () => {
+  it('renders 8 number inputs (4 per IP)', () => {
+    render(
+      <IpRangeInput
+        onChange={vi.fn()}
+        value={RANGE_BASIC}
+      />
+    )
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(TOTAL_OCTET_INPUTS)
+  })
+
+  it('splits the value on the first hyphen and populates both IpInputs', () => {
+    render(
+      <IpRangeInput
+        onChange={vi.fn()}
+        value={RANGE_DETAILED}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    expect(inputs[0]).toHaveValue(OCTET_192)
+    expect(inputs[1]).toHaveValue(OCTET_168)
+    expect(inputs[2]).toHaveValue(OCTET_1)
+    expect(inputs[3]).toHaveValue(OCTET_1)
+    expect(inputs[4]).toHaveValue(OCTET_192)
+    expect(inputs[5]).toHaveValue(OCTET_168)
+    expect(inputs[6]).toHaveValue(OCTET_1)
+    expect(inputs[7]).toHaveValue(OCTET_100)
+  })
+
+  it('emits combined start-end string when start changes', () => {
+    const onChange = vi.fn()
+    render(
+      <IpRangeInput
+        onChange={onChange}
+        value={RANGE_BASIC}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[3], { target: { value: String(OCTET_5) } })
+    expect(onChange).toHaveBeenCalledWith('10.0.0.5-10.0.0.50')
+  })
+
+  it('emits combined start-end string when end changes', () => {
+    const onChange = vi.fn()
+    render(
+      <IpRangeInput
+        onChange={onChange}
+        value={RANGE_BASIC}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[7], { target: { value: String(OCTET_99) } })
+    expect(onChange).toHaveBeenCalledWith('10.0.0.1-10.0.0.99')
+  })
+
+  it('emits EMPTY_STRING when required=true and start becomes blank', () => {
+    const onChange = vi.fn()
+    render(
+      <IpRangeInput
+        onChange={onChange}
+        required
+        value={RANGE_BASIC}
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: EMPTY_STRING } })
+    expect(onChange).toHaveBeenCalledWith(EMPTY_STRING)
+  })
+
+  it('shows the label when provided', () => {
+    render(
+      <IpRangeInput
+        label='IP Range'
+        onChange={vi.fn()}
+        value={EMPTY_STRING}
+      />
+    )
+    expect(screen.getByText('IP Range')).toBeInTheDocument()
+  })
+
+  it('shows required star when required=true and label is set', () => {
+    render(
+      <IpRangeInput
+        label='IP Range'
+        onChange={vi.fn()}
+        required
+        value={EMPTY_STRING}
+      />
+    )
+    expect(screen.getByText('*')).toBeInTheDocument()
+  })
+})

--- a/lib/v2/components/inputs/IpRangeInput/IpRangeInput.tsx
+++ b/lib/v2/components/inputs/IpRangeInput/IpRangeInput.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react'
+import clsx from 'clsx'
+
+import { EMPTY_STRING } from '#v2/utils/consts'
+
+import { IpInput } from '../IpInput'
+
+import styles from './ipRangeInput.module.scss'
+
+export interface IpRangeInputProps {
+  value: string
+  onChange: (value: string) => void
+  label?: string
+  startLabel?: string
+  endLabel?: string
+  disabled?: boolean
+  required?: boolean
+  error?: string
+  info?: string
+}
+
+function parseRange(value: string): { start: string; end: string } {
+  if (!value) {
+    return { start: EMPTY_STRING, end: EMPTY_STRING }
+  }
+  const idx = value.indexOf('-')
+  if (idx === -1) {
+    return { start: value, end: EMPTY_STRING }
+  }
+  return { start: value.slice(0, idx), end: value.slice(idx + 1) }
+}
+
+export function IpRangeInput({
+  value,
+  onChange,
+  label,
+  startLabel,
+  endLabel,
+  disabled = false,
+  required = false,
+  error
+}: Readonly<IpRangeInputProps>) {
+  const [start, setStart] = useState(() => parseRange(value).start)
+  const [end, setEnd] = useState(() => parseRange(value).end)
+  const [lastValue, setLastValue] = useState(value)
+
+  if (value !== lastValue) {
+    setLastValue(value)
+    const parsed = parseRange(value)
+    setStart(parsed.start)
+    setEnd(parsed.end)
+  }
+
+  function emit(nextStart: string, nextEnd: string) {
+    const nextValue =
+      nextStart && nextEnd ? `${nextStart}-${nextEnd}` : EMPTY_STRING
+    setLastValue(nextValue)
+    onChange(nextValue)
+  }
+
+  function handleStartChange(newStart: string) {
+    setStart(newStart)
+    emit(newStart, end)
+  }
+
+  function handleEndChange(newEnd: string) {
+    setEnd(newEnd)
+    emit(start, newEnd)
+  }
+
+  return (
+    <div className={clsx(styles.wrapper, error && styles.hasError)}>
+      {label ? (
+        <span className={styles.label}>
+          {label}
+          {required ? <span className={styles.requiredStar}> *</span> : null}
+        </span>
+      ) : null}
+      <div className={styles.rangeRow}>
+        <div className={styles.ipBox}>
+          <IpInput
+            disabled={disabled}
+            label={startLabel}
+            onChange={handleStartChange}
+            required={required}
+            value={start}
+          />
+        </div>
+        <span className={styles.rangeSeparator}>–</span>
+        <div className={styles.ipBox}>
+          <IpInput
+            disabled={disabled}
+            label={endLabel}
+            onChange={handleEndChange}
+            required={required}
+            value={end}
+          />
+        </div>
+      </div>
+      {error ? <span className={styles.errorText}>{error}</span> : null}
+    </div>
+  )
+}

--- a/lib/v2/components/inputs/IpRangeInput/index.ts
+++ b/lib/v2/components/inputs/IpRangeInput/index.ts
@@ -1,0 +1,2 @@
+export type { IpRangeInputProps } from './IpRangeInput'
+export { IpRangeInput } from './IpRangeInput'

--- a/lib/v2/components/inputs/IpRangeInput/ipRangeInput.module.scss
+++ b/lib/v2/components/inputs/IpRangeInput/ipRangeInput.module.scss
@@ -1,0 +1,46 @@
+@use '../../../styles/colors' as *;
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--gray-600-400);
+  margin-bottom: 6px;
+  padding-left: 4px;
+}
+
+.requiredStar {
+  color: var(--red-500);
+}
+
+.rangeRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.ipBox {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.rangeSeparator {
+  font-size: 16px;
+  color: var(--gray-600-400);
+  flex-shrink: 0;
+  user-select: none;
+  margin: 0 8px;
+}
+
+.errorText {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--red-500);
+  padding-left: 4px;
+}

--- a/lib/v2/components/inputs/IpRangeInput/ipRangeInputStories.module.scss
+++ b/lib/v2/components/inputs/IpRangeInput/ipRangeInputStories.module.scss
@@ -1,0 +1,11 @@
+@use '../../../styles/colors' as *;
+
+.container {
+  width: 400px;
+}
+
+.valueDisplay {
+  margin-top: 24px;
+  font-size: 12px;
+  color: var(--gray-700-300);
+}

--- a/lib/v2/components/inputs/MultiSelectAutocomplete/multiSelectAutocomplete.module.scss
+++ b/lib/v2/components/inputs/MultiSelectAutocomplete/multiSelectAutocomplete.module.scss
@@ -120,7 +120,7 @@
   font-family: 'IBMPlexSans', sans-serif;
 
   &::placeholder {
-    color: var(--gray-920-50);
+    color: var(--gray-500);
   }
 }
 

--- a/lib/v2/components/inputs/NumberInput/numberInput.module.scss
+++ b/lib/v2/components/inputs/NumberInput/numberInput.module.scss
@@ -54,7 +54,7 @@
   }
 
   &::placeholder {
-    color: var(--gray-920-50);
+    color: var(--gray-500);
   }
 
   &::-webkit-outer-spin-button,

--- a/lib/v2/components/inputs/Select/Select.stories.tsx
+++ b/lib/v2/components/inputs/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import type { SelectOption } from './Select'
+import type { SelectOption, SelectOptionValue } from './Select'
 import type { Meta, StoryObj } from '@storybook/react'
 import type { CSSProperties } from 'react'
 
@@ -77,19 +77,26 @@ const ASYNC_INITIAL_OPTIONS = MANY_OPTIONS.slice(0, ASYNC_RESULT_LIMIT)
 const NOOP = NOP
 
 function SelectDemo() {
-  const [region, setRegion] = useState<string | string[]>(EMPTY_STRING)
-  const [severities, setSeverities] = useState<string | string[]>([
-    'critical',
-    'major'
-  ])
-  const [anyAllowed, setAnyAllowed] = useState<string | string[]>([ANY_VALUE])
-  const [bucket, setBucket] = useState<string | string[]>(EMPTY_STRING)
+  const [region, setRegion] = useState<SelectOptionValue | SelectOptionValue[]>(
+    EMPTY_STRING
+  )
+  const [severities, setSeverities] = useState<
+    SelectOptionValue | SelectOptionValue[]
+  >(['critical', 'major'])
+  const [anyAllowed, setAnyAllowed] = useState<
+    SelectOptionValue | SelectOptionValue[]
+  >([ANY_VALUE])
+  const [bucket, setBucket] = useState<SelectOptionValue | SelectOptionValue[]>(
+    EMPTY_STRING
+  )
 
   const [asyncResults, setAsyncResults] = useState<SelectOption[]>(
     ASYNC_INITIAL_OPTIONS
   )
   const [asyncLoading, setAsyncLoading] = useState(false)
-  const [asyncPick, setAsyncPick] = useState<string | string[]>(EMPTY_STRING)
+  const [asyncPick, setAsyncPick] = useState<
+    SelectOptionValue | SelectOptionValue[]
+  >(EMPTY_STRING)
 
   const renderSeverityOption = useCallback(
     (option: SelectOption) => {

--- a/lib/v2/components/inputs/Select/Select.tsx
+++ b/lib/v2/components/inputs/Select/Select.tsx
@@ -28,6 +28,12 @@ import { highlightText } from '#v2/utils/textUtils'
 
 import { ChevronDownSmallIcon, CloseIcon, SearchIcon } from '../../../icons'
 import { Chip } from '../../Chip'
+import {
+  applyAnyValueRules,
+  getNextEnabledIndex,
+  normalizeSelectValue,
+  type SelectOptionValue
+} from './selectUtils'
 import { SplitMenuList } from './SplitMenuList'
 
 import styles from './select.module.scss'
@@ -45,53 +51,30 @@ const DEFAULT_PLACEHOLDER = 'Select...'
 const DEFAULT_CHIP_TEXT_COLOR = 'var(--gray-900-100)'
 const DEFAULT_CHIP_BACKGROUND_COLOR = 'var(--purple-100-900)'
 
-function applyAnyValueRules(
-  nextValues: string[],
-  prevValues: string[],
-  anyValue: string | undefined
-): string[] {
-  if (!anyValue) {
-    return nextValues
-  }
-
-  if (nextValues.length === 0) {
-    return [anyValue]
-  }
-
-  const prevHadAny = prevValues.includes(anyValue)
-  const nextHasAny = nextValues.includes(anyValue)
-
-  if (nextHasAny && !prevHadAny) {
-    return [anyValue]
-  }
-
-  if (nextHasAny && nextValues.length > 1) {
-    return nextValues.filter((entry) => entry !== anyValue)
-  }
-
-  return nextValues
-}
+export type { SelectOptionValue } from './selectUtils'
 
 export interface SelectOption {
-  value: string
+  value: SelectOptionValue
   label: string
   icon?: ReactNode
   chipBackgroundColor?: string
   chipTextColor?: string
+  subLabel?: string
+  disabled?: boolean
 }
 
 export interface SelectProps {
   label?: string
   placeholder?: string
   options: SelectOption[]
-  value: string | string[]
-  onChange: (value: string | string[]) => void
+  value?: SelectOptionValue | SelectOptionValue[]
+  onChange(value: SelectOptionValue | SelectOptionValue[]): void
   disabled?: boolean
   multiple?: boolean
   required?: boolean
   renderChip?: (option: SelectOption, onRemove: () => void) => ReactNode
   renderOption?: (option: SelectOption) => ReactNode
-  anyValue?: string
+  anyValue?: SelectOptionValue
   maxVisibleChips?: number
   isLoading?: boolean
   onSearch?: (query: string) => void | Promise<void>
@@ -105,7 +88,7 @@ export function Select({
   label,
   placeholder = DEFAULT_PLACEHOLDER,
   options,
-  value,
+  value: valueProp,
   onChange,
   disabled = false,
   multiple = false,
@@ -121,6 +104,7 @@ export function Select({
   searchThreshold = DEFAULT_SEARCH_THRESHOLD,
   dataTestId
 }: Readonly<SelectProps>) {
+  const value = normalizeSelectValue(valueProp, multiple)
   const [searchQuery, setSearchQuery] = useState(EMPTY_STRING)
   const [isOpen, setIsOpen] = useState(false)
   const [openUpward, setOpenUpward] = useState(false)
@@ -136,21 +120,31 @@ export function Select({
   const showSearch = options.length > searchThreshold || !!searchQuery
 
   const optionsWithSelected = useMemo(() => {
-    const selectedValues = multiple ? (value as string[]) : [value as string]
+    const selectedValues = multiple
+      ? (value as SelectOptionValue[])
+      : [value as SelectOptionValue]
     const result = [...options]
 
-    selectedValues.filter(Boolean).forEach((val) => {
-      if (!result.some((opt) => opt.value === val)) {
-        result.unshift({ value: val, label: val })
-      }
-    })
+    selectedValues
+      .filter((v) => v !== undefined && v !== null && v !== EMPTY_STRING)
+      .forEach((val) => {
+        if (!result.some((opt) => opt.value === val)) {
+          result.unshift({ value: val, label: String(val) })
+        }
+      })
 
     return result
   }, [options, value, multiple])
 
   const filteredOptions = useMemo(() => {
-    const selectedValues = multiple ? (value as string[]) : [value as string]
-    const selectedSet = new Set(selectedValues.filter(Boolean))
+    const selectedValues = multiple
+      ? (value as SelectOptionValue[])
+      : [value as SelectOptionValue]
+    const selectedSet = new Set(
+      selectedValues.filter(
+        (v) => v !== undefined && v !== null && v !== EMPTY_STRING
+      )
+    )
 
     let baseOptions = optionsWithSelected
 
@@ -168,7 +162,7 @@ export function Select({
         if (fullOption) {
           missingSelectedOptions.push(fullOption)
         } else {
-          missingSelectedOptions.push({ value: val, label: val })
+          missingSelectedOptions.push({ value: val, label: String(val) })
         }
       }
     })
@@ -222,30 +216,40 @@ export function Select({
     [onSearch, searchDebounceMs, minSearchLength]
   )
 
-  const handleChange = (e: SelectChangeEvent<string | string[]>) => {
+  const handleChange = (
+    e: SelectChangeEvent<SelectOptionValue | SelectOptionValue[]>
+  ) => {
     const incoming = e.target.value
     if (!multiple) {
       onChange(incoming)
       return
     }
     onChange(
-      applyAnyValueRules(incoming as string[], value as string[], anyValue)
+      applyAnyValueRules(
+        incoming as SelectOptionValue[],
+        value as SelectOptionValue[],
+        anyValue
+      )
     )
   }
 
-  const handleRemoveChip = (valueToRemove: string) => {
+  const handleRemoveChip = (valueToRemove: SelectOptionValue) => {
     if (!multiple || !Array.isArray(value)) {
       return
     }
-    const remaining = value.filter((entry) => entry !== valueToRemove)
-    onChange(applyAnyValueRules(remaining, value, anyValue))
+    const remaining = (value as SelectOptionValue[]).filter(
+      (entry) => entry !== valueToRemove
+    )
+    onChange(
+      applyAnyValueRules(remaining, value as SelectOptionValue[], anyValue)
+    )
   }
 
   const getSelectedOptions = () => {
     if (!multiple || !Array.isArray(value)) {
       return []
     }
-    return value
+    return (value as SelectOptionValue[])
       .map((selectedValue) =>
         optionsWithSelected.find((option) => option.value === selectedValue)
       )
@@ -254,9 +258,9 @@ export function Select({
 
   const getDisplayValue = () => {
     if (multiple) {
-      return value as string[]
+      return value as SelectOptionValue[]
     }
-    return value as string
+    return value as SelectOptionValue
   }
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -300,6 +304,39 @@ export function Select({
     }
   }
 
+  const commitHighlightedOption = () => {
+    if (highlightedIndex < 0 || highlightedIndex >= filteredOptions.length) {
+      return
+    }
+    const selectedOption = filteredOptions[highlightedIndex]
+    if (selectedOption.disabled) {
+      return
+    }
+    if (multiple) {
+      const currentValue = value as SelectOptionValue[]
+      const isAlreadySelected = currentValue.includes(selectedOption.value)
+      const toggled = isAlreadySelected
+        ? currentValue.filter((entry) => entry !== selectedOption.value)
+        : [...currentValue, selectedOption.value]
+      onChange(applyAnyValueRules(toggled, currentValue, anyValue))
+    } else {
+      onChange(selectedOption.value)
+      setIsOpen(false)
+    }
+  }
+
+  const moveHighlight = (step: number) => {
+    setHighlightedIndex((prev) => {
+      const nextIndex = getNextEnabledIndex(filteredOptions, prev, step)
+      if (step < 0 && nextIndex === prev && showSearch) {
+        searchInputRef.current?.focus()
+        return NO_HIGHLIGHT
+      }
+      scrollToHighlightedItem(nextIndex)
+      return nextIndex
+    })
+  }
+
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (filteredOptions.length === 0) {
       return
@@ -309,24 +346,12 @@ export function Select({
       case KEYBOARD_KEYS.ARROW_DOWN:
         e.preventDefault()
         e.stopPropagation()
-        setHighlightedIndex((prev) => {
-          const nextIndex = prev < filteredOptions.length - 1 ? prev + 1 : prev
-          scrollToHighlightedItem(nextIndex)
-          return nextIndex
-        })
+        moveHighlight(1)
         break
       case KEYBOARD_KEYS.ARROW_UP:
         e.preventDefault()
         e.stopPropagation()
-        setHighlightedIndex((prev) => {
-          const nextIndex = prev > 0 ? prev - 1 : NO_HIGHLIGHT
-          if (nextIndex === NO_HIGHLIGHT && showSearch) {
-            searchInputRef.current?.focus()
-          } else {
-            scrollToHighlightedItem(nextIndex)
-          }
-          return nextIndex
-        })
+        moveHighlight(-1)
         break
       case KEYBOARD_KEYS.ENTER:
         if (
@@ -335,33 +360,24 @@ export function Select({
         ) {
           e.preventDefault()
           e.stopPropagation()
-          const selectedOption = filteredOptions[highlightedIndex]
-          if (multiple) {
-            const currentValue = value as string[]
-            const isAlreadySelected = currentValue.includes(
-              selectedOption.value
-            )
-            const toggled = isAlreadySelected
-              ? currentValue.filter((entry) => entry !== selectedOption.value)
-              : [...currentValue, selectedOption.value]
-            onChange(applyAnyValueRules(toggled, currentValue, anyValue))
-          } else {
-            onChange(selectedOption.value)
-            setIsOpen(false)
-          }
+          commitHighlightedOption()
         }
         break
     }
   }
 
-  const renderSingleValue = (selectedValue: string): ReactNode => {
-    if (!selectedValue) {
+  const renderSingleValue = (selectedValue: SelectOptionValue): ReactNode => {
+    if (
+      selectedValue === undefined ||
+      selectedValue === null ||
+      selectedValue === EMPTY_STRING
+    ) {
       return <span className={styles.placeholder}>{placeholder}</span>
     }
     const selectedOption = optionsWithSelected.find(
       (opt) => opt.value === selectedValue
     )
-    const displayText = selectedOption?.label || selectedValue
+    const displayText = selectedOption?.label || String(selectedValue)
     return (
       <span
         className={styles.selectedValue}
@@ -372,7 +388,9 @@ export function Select({
     )
   }
 
-  const renderMultipleValue = (selectedArray: string[]): ReactNode => {
+  const renderMultipleValue = (
+    selectedArray: SelectOptionValue[]
+  ): ReactNode => {
     if (selectedArray.length === 0) {
       return <span className={styles.placeholder}>{placeholder}</span>
     }
@@ -463,6 +481,7 @@ export function Select({
           }
         }}
         data-testid={`select-option-${option.value}`}
+        disabled={option.disabled}
         value={option.value}
         className={clsx(styles.menuItem, {
           [styles.highlighted]: index === highlightedIndex
@@ -475,13 +494,18 @@ export function Select({
             {option.icon ? (
               <span className={styles.menuItemIcon}>{option.icon}</span>
             ) : null}
-            <span>
+            <span className={styles.menuItemText}>
               {highlightText(
                 option.label,
                 searchQuery,
                 'mark',
                 styles.highlight
               )}
+              {option.subLabel ? (
+                <span className={styles.menuItemSubLabel}>
+                  {option.subLabel}
+                </span>
+              ) : null}
             </span>
           </div>
         )}
@@ -546,8 +570,8 @@ export function Select({
         }}
         renderValue={(selected) =>
           multiple
-            ? renderMultipleValue(selected as string[])
-            : renderSingleValue(selected as string)
+            ? renderMultipleValue(selected as SelectOptionValue[])
+            : renderSingleValue(selected as SelectOptionValue)
         }
       >
         {showSearch ? (

--- a/lib/v2/components/inputs/Select/index.ts
+++ b/lib/v2/components/inputs/Select/index.ts
@@ -1,2 +1,2 @@
-export type { SelectOption, SelectProps } from './Select'
+export type { SelectOption, SelectOptionValue, SelectProps } from './Select'
 export { Select } from './Select'

--- a/lib/v2/components/inputs/Select/select.module.scss
+++ b/lib/v2/components/inputs/Select/select.module.scss
@@ -104,7 +104,7 @@
 }
 
 .placeholder {
-  color: var(--gray-920-50) !important;
+  color: var(--gray-500) !important;
   font-weight: 400;
   pointer-events: none !important;
 }
@@ -248,9 +248,7 @@
   border-radius: 4px;
   padding: 6px 8px;
   gap: 8px;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 
   &:focus-within {
     border-color: var(--purple-500);
@@ -352,6 +350,21 @@
     white-space: nowrap;
     flex: 1;
   }
+}
+
+.menuItemText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.menuItemSubLabel {
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--gray-600-400);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .menuItemIcon {

--- a/lib/v2/components/inputs/Select/selectUtils.ts
+++ b/lib/v2/components/inputs/Select/selectUtils.ts
@@ -1,0 +1,56 @@
+import { EMPTY_STRING } from '#v2/utils/consts'
+
+export type SelectOptionValue = string | number
+
+export function normalizeSelectValue(
+  value: SelectOptionValue | SelectOptionValue[] | undefined,
+  multiple: boolean
+): SelectOptionValue | SelectOptionValue[] {
+  if (value !== undefined) {
+    return value
+  }
+  return multiple ? [] : EMPTY_STRING
+}
+
+export function getNextEnabledIndex(
+  options: readonly { disabled?: boolean }[],
+  current: number,
+  step: number
+): number {
+  let next = current + step
+  while (next >= 0 && next < options.length && options[next].disabled) {
+    next += step
+  }
+  return next >= 0 && next < options.length ? next : current
+}
+
+/**
+ * Enforce the "any" option's exclusivity in a multi-select: selecting `anyValue`
+ * clears every other value, and selecting any other value clears `anyValue`.
+ */
+export function applyAnyValueRules(
+  nextValues: SelectOptionValue[],
+  prevValues: SelectOptionValue[],
+  anyValue: SelectOptionValue | undefined
+): SelectOptionValue[] {
+  if (!anyValue) {
+    return nextValues
+  }
+
+  if (nextValues.length === 0) {
+    return [anyValue]
+  }
+
+  const prevHadAny = prevValues.includes(anyValue)
+  const nextHasAny = nextValues.includes(anyValue)
+
+  if (nextHasAny && !prevHadAny) {
+    return [anyValue]
+  }
+
+  if (nextHasAny && nextValues.length > 1) {
+    return nextValues.filter((entry) => entry !== anyValue)
+  }
+
+  return nextValues
+}

--- a/lib/v2/components/inputs/TextArea/textArea.module.scss
+++ b/lib/v2/components/inputs/TextArea/textArea.module.scss
@@ -52,6 +52,6 @@
   }
 
   &::placeholder {
-    color: var(--gray-920-50);
+    color: var(--gray-500);
   }
 }

--- a/lib/v2/components/inputs/TextInput/textInput.module.scss
+++ b/lib/v2/components/inputs/TextInput/textInput.module.scss
@@ -58,6 +58,6 @@
   }
 
   &::placeholder {
-    color: var(--gray-920-50);
+    color: var(--gray-500);
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "type": "module",
-  "version": "4.35.0",
+  "version": "4.36.0",
   "module": "lib/main.ts",
   "types": "lib/main.ts",
   "imports": {


### PR DESCRIPTION
Bumps `@weka/weka-ui-components` to **4.36.0**. Batches the v2 changes needed by the NeuralMesh Tenants page (and general fixes).

## New components
- **IpInput** — 4-octet IPv4 field (`.` separators, label-inside, keyboard nav, auto-advance, paste-to-distribute, 0–255 clamp).
- **IpRangeInput** — start–end range on two IpInputs; both keep internal state and re-seed from `value` only on a complete external change, so a partially-filled range no longer drops the side already entered.

## Select
- `SelectOption` gains **`disabled`** (skipped on click/keyboard) and **`subLabel`**.
- Widen option/value type to **`string | number`** (`SelectOptionValue`) so numeric-valued options (capacity/duration units) type-check.
- Extracted `applyAnyValueRules` + the value type into `selectUtils.ts`.

## Table
- `tableContainer` `flex:1` — short/compact tables fill their wrapper, footer pinned to bottom (no empty band).
- Column-settings menu now positions **fixed** to the viewport (flips above when needed) instead of a brittle class-name match, so it isn't clipped by a short table's `overflow:hidden`.

## Inputs
- Muted placeholder color (`--gray-500`) across TextInput/NumberInput/TextArea/Select/MultiSelectAutocomplete (was near text-color, "too white" in dark mode).
- FilterPopover "Select All" label now visible in dark mode.

## Checks
eslint 0 errors · prettier formatted · tsc clean (v2) · vitest 141/141 on changed components · `vite build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)