### PR TITLE
chore: restore version to 4.35.0 for auto-release (fixes failed v4.36.0 publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "type": "module",
-  "version": "4.36.0",
+  "version": "4.35.0",
   "module": "lib/main.ts",
   "types": "lib/main.ts",
   "imports": {


### PR DESCRIPTION
The v4.36.0 PR manually set `package.json` to 4.36.0, but the **auto-release** workflow owns the bump — it computes the next version from the latest git tag (`v4.35.0` → `4.36.0`), runs `npm version`, then commits `package.json`. A pre-bumped file made that commit a no-op ("nothing to commit") → publish failed.

This restores `package.json` to **4.35.0** (last published). On merge, auto-release will bump **4.35.0 → 4.36.0** (minor; no `patch` label) and publish/tag as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)