### PR TITLE
feat(v2): Table endless-scroll, in-frame loader & manual filtering; DateTimePicker/severity/filter refinements

### DIFF
--- a/lib/v2/components/DateTimePicker/DateTimePicker.tsx
+++ b/lib/v2/components/DateTimePicker/DateTimePicker.tsx
@@ -1,3 +1,4 @@
+import type { PopperProps } from '@mui/material'
 import type { DateTime } from 'luxon'
 
 import { useCallback, useState } from 'react'
@@ -23,6 +24,7 @@ export interface DateTimePickerProps {
   showNow?: boolean
   enableCustomFormat?: boolean
   customFormat?: string
+  popperProps?: Partial<PopperProps>
 }
 
 export function DateTimePicker({
@@ -37,7 +39,8 @@ export function DateTimePicker({
   canClear = true,
   showNow,
   enableCustomFormat,
-  customFormat
+  customFormat,
+  popperProps
 }: Readonly<DateTimePickerProps>) {
   const [isOpen, setIsOpen] = useState(false)
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
@@ -71,7 +74,9 @@ export function DateTimePicker({
         disablePortal={disablePortal}
         open={isOpen}
         placement='top'
+        popperOptions={{ strategy: 'fixed' }}
         transition
+        {...popperProps}
       >
         {({ TransitionProps }) => (
           <Grow

--- a/lib/v2/components/DateTimePicker/components/DateSelector/dateSelector.module.scss
+++ b/lib/v2/components/DateTimePicker/components/DateSelector/dateSelector.module.scss
@@ -12,6 +12,7 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  color: var(--text-color-primary);
 }
 
 .dateController {

--- a/lib/v2/components/DateTimePicker/components/DateTimeCalendar/dateTimeCalendar.module.scss
+++ b/lib/v2/components/DateTimePicker/components/DateTimeCalendar/dateTimeCalendar.module.scss
@@ -1,5 +1,6 @@
 .calendarWrapper {
   background-color: var(--gray-100-900);
+  color: var(--text-color-primary);
   border: 1px solid var(--gray-300-700);
   padding: 8px;
   box-sizing: border-box;

--- a/lib/v2/components/DateTimePicker/components/DayCell/DayCell.tsx
+++ b/lib/v2/components/DateTimePicker/components/DayCell/DayCell.tsx
@@ -1,6 +1,9 @@
 import type { DateTime } from 'luxon'
 
-import { isDayDisabled } from '../../utils/dateTimeUtils'
+import {
+  isDayOutOfBounds,
+  isDayOutsideMonth
+} from '../../utils/dateTimeUtils'
 
 import styles from './dayCell.module.scss'
 
@@ -21,11 +24,16 @@ export function DayCell({
   minDate = null,
   maxDate = null
 }: Readonly<DayCellProps>) {
-  const isDisabled = isDayDisabled(date, month, minDate, maxDate)
+  const outOfBounds = isDayOutOfBounds(date, minDate, maxDate)
+  const outsideMonth = isDayOutsideMonth(date, month)
+  const isDisabled = outOfBounds || outsideMonth
 
   const getClassName = () => {
-    if (isDisabled) {
+    if (outOfBounds) {
       return styles.cellDayDisabled
+    }
+    if (outsideMonth) {
+      return styles.cellDayOutsideMonth
     }
     if (selected) {
       return styles.cellDaySelected

--- a/lib/v2/components/DateTimePicker/components/DayCell/dayCell.module.scss
+++ b/lib/v2/components/DateTimePicker/components/DayCell/dayCell.module.scss
@@ -12,7 +12,15 @@
 .cellDayDisabled {
   composes: cellDay;
   cursor: not-allowed;
-  color: var(--gray-400-600);
+  color: inherit;
+  opacity: 0.35;
+}
+
+.cellDayOutsideMonth {
+  composes: cellDay;
+  cursor: default;
+  color: inherit;
+  opacity: 0.55;
 }
 
 .cellDayActive {

--- a/lib/v2/components/DateTimePicker/components/NumInput/numInput.module.scss
+++ b/lib/v2/components/DateTimePicker/components/NumInput/numInput.module.scss
@@ -7,7 +7,7 @@
   border: 1px solid var(--gray-300-700);
   border-radius: 4px;
   font-size: 14px;
-  background-color: var(--gray-50-950);
+  background-color: var(--gray-100-900);
   color: var(--text-color-primary);
   outline: none;
   transition: all 0.2s ease;
@@ -22,7 +22,7 @@
   input {
     border: none;
     color: var(--gray-950-20);
-    background-color: var(--gray-50-950) !important;
+    background-color: var(--gray-100-900) !important;
     margin-right: 5px;
   }
 

--- a/lib/v2/components/DateTimePicker/components/TimeSelector/timeSelector.module.scss
+++ b/lib/v2/components/DateTimePicker/components/TimeSelector/timeSelector.module.scss
@@ -20,7 +20,6 @@
   gap: 8px;
 
   input {
-    background-color: var(--gray-100-900);
     width: 20px;
     text-align: center;
     -moz-appearance: textfield;

--- a/lib/v2/components/DateTimePicker/dateTimePicker.module.scss
+++ b/lib/v2/components/DateTimePicker/dateTimePicker.module.scss
@@ -38,7 +38,7 @@
 }
 
 .popperWrapper {
-  z-index: 1400;
+  z-index: 10010;
 }
 
 .menuPopper {

--- a/lib/v2/components/DateTimePicker/utils/dateTimeUtils.test.ts
+++ b/lib/v2/components/DateTimePicker/utils/dateTimeUtils.test.ts
@@ -1,11 +1,17 @@
 import { DateTime } from 'luxon'
 import { describe, expect, it } from 'vitest'
 
-import { clampDateTime, isDayDisabled } from './dateTimeUtils'
+import {
+  clampDateTime,
+  isDayDisabled,
+  isDayOutOfBounds,
+  isDayOutsideMonth
+} from './dateTimeUtils'
 
 const MARCH_START = '2024-03-01T00:00:00'
 const MARCH_END = '2024-03-31T23:59:59'
 const MID_MARCH = '2024-03-15'
+const MID_APRIL = '2024-04-15'
 
 describe('clampDateTime', () => {
   const baseDate = DateTime.fromISO('2024-03-15T12:00:00')
@@ -67,7 +73,7 @@ describe('clampDateTime', () => {
 
 describe('isDayDisabled', () => {
   const marchDate = DateTime.fromISO(MID_MARCH)
-  const aprilDate = DateTime.fromISO('2024-04-15')
+  const aprilDate = DateTime.fromISO(MID_APRIL)
   const marchMonth = 3
 
   it('returns false for date in current month within bounds', () => {
@@ -106,5 +112,44 @@ describe('isDayDisabled', () => {
     const minDate = DateTime.fromISO('2024-03-01')
     const maxDate = DateTime.fromISO('2024-04-30')
     expect(isDayDisabled(aprilDate, marchMonth, minDate, maxDate)).toBe(true)
+  })
+})
+
+describe('isDayOutOfBounds', () => {
+  const marchDate = DateTime.fromISO(MID_MARCH)
+
+  it('returns false when no bounds are provided', () => {
+    expect(isDayOutOfBounds(marchDate)).toBe(false)
+  })
+
+  it('returns true when date is after maxDate', () => {
+    const maxDate = DateTime.fromISO('2024-03-10')
+    expect(isDayOutOfBounds(marchDate, null, maxDate)).toBe(true)
+  })
+
+  it('returns true when date is before minDate', () => {
+    const minDate = DateTime.fromISO('2024-03-20')
+    expect(isDayOutOfBounds(marchDate, minDate)).toBe(true)
+  })
+
+  it('ignores the displayed month', () => {
+    const aprilDate = DateTime.fromISO(MID_APRIL)
+    expect(isDayOutOfBounds(aprilDate)).toBe(false)
+  })
+})
+
+describe('isDayOutsideMonth', () => {
+  const marchMonth = 3
+
+  it('returns false for a day in the displayed month', () => {
+    expect(isDayOutsideMonth(DateTime.fromISO(MID_MARCH), marchMonth)).toBe(
+      false
+    )
+  })
+
+  it('returns true for a day in another month', () => {
+    expect(isDayOutsideMonth(DateTime.fromISO(MID_APRIL), marchMonth)).toBe(
+      true
+    )
   })
 })

--- a/lib/v2/components/DateTimePicker/utils/dateTimeUtils.ts
+++ b/lib/v2/components/DateTimePicker/utils/dateTimeUtils.ts
@@ -18,7 +18,27 @@ export function clampDateTime(
 }
 
 /**
- * Determines if a day cell should be disabled based on month and date bounds.
+ * Determines if a day falls outside the allowed min/max bounds.
+ */
+export function isDayOutOfBounds(
+  date: DateTime,
+  minDate?: DateTime | null,
+  maxDate?: DateTime | null
+): boolean {
+  return (
+    (maxDate ? date > maxDate : false) || (minDate ? date < minDate : false)
+  )
+}
+
+/**
+ * Determines if a day belongs to a month other than the one being displayed.
+ */
+export function isDayOutsideMonth(date: DateTime, currentMonth: number): boolean {
+  return currentMonth !== date.month
+}
+
+/**
+ * Determines if a day cell should be non-selectable based on month and date bounds.
  */
 export function isDayDisabled(
   date: DateTime,
@@ -27,8 +47,7 @@ export function isDayDisabled(
   maxDate?: DateTime | null
 ): boolean {
   return (
-    currentMonth !== date.month ||
-    (maxDate ? date > maxDate : false) ||
-    (minDate ? date < minDate : false)
+    isDayOutsideMonth(date, currentMonth) ||
+    isDayOutOfBounds(date, minDate, maxDate)
   )
 }

--- a/lib/v2/components/LoadingState/LoadingState.tsx
+++ b/lib/v2/components/LoadingState/LoadingState.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react'
 
 import clsx from 'clsx'
 
+import { Spinner } from '../Spinner'
+
 import styles from './loadingState.module.scss'
 
 const STATE_TYPES = {
@@ -43,14 +45,7 @@ export function LoadingState({
       data-testid={TEST_IDS[type]}
     >
       <div className={styles.content}>
-        {type === STATE_TYPES.LOADING && (
-          <div className={styles.spinner}>
-            <div className={styles.spinnerDot} />
-            <div className={styles.spinnerDot} />
-            <div className={styles.spinnerDot} />
-            <div className={styles.spinnerDot} />
-          </div>
-        )}
+        {type === STATE_TYPES.LOADING && <Spinner />}
         <div className={styles.message}>{displayMessage}</div>
         {children}
       </div>

--- a/lib/v2/components/LoadingState/loadingState.module.scss
+++ b/lib/v2/components/LoadingState/loadingState.module.scss
@@ -30,50 +30,6 @@
   padding: 32px;
 }
 
-.spinner {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.spinnerDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--purple-500);
-  animation: pulse 1.4s ease-in-out infinite;
-
-  &:nth-child(1) {
-    animation-delay: -0.32s;
-  }
-
-  &:nth-child(2) {
-    animation-delay: -0.16s;
-  }
-
-  &:nth-child(3) {
-    animation-delay: 0s;
-  }
-
-  &:nth-child(4) {
-    animation-delay: 0.16s;
-  }
-}
-
-@keyframes pulse {
-  0%,
-  80%,
-  100% {
-    transform: scale(0.7);
-    opacity: 0.5;
-  }
-
-  40% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
 .message {
   font-size: 14px;
   font-weight: 500;

--- a/lib/v2/components/SeverityChip/severityChip.module.scss
+++ b/lib/v2/components/SeverityChip/severityChip.module.scss
@@ -13,7 +13,7 @@
   padding: 2px 8px !important;
   font-size: 14px !important;
   font-weight: 700 !important;
-  border-radius: 20px;
+  border-radius: 2px !important;
 
   svg {
     width: 16px !important;

--- a/lib/v2/components/Spinner/Spinner.stories.tsx
+++ b/lib/v2/components/Spinner/Spinner.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Spinner } from './Spinner'
+
+const meta: Meta<typeof Spinner> = {
+  title: 'v2/Spinner',
+  component: Spinner,
+  tags: ['autodocs']
+}
+
+export default meta
+type Story = StoryObj<typeof Spinner>
+
+export const Default: Story = {}

--- a/lib/v2/components/Spinner/Spinner.test.tsx
+++ b/lib/v2/components/Spinner/Spinner.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Spinner } from './Spinner'
+
+const EXPECTED_DOT_COUNT = 4
+
+describe('Spinner', () => {
+  it('renders the spinner container', () => {
+    const { container } = render(<Spinner />)
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('renders four animated dots', () => {
+    const { container } = render(<Spinner />)
+    const dots = container.querySelectorAll('[class*="spinnerDot"]')
+    expect(dots).toHaveLength(EXPECTED_DOT_COUNT)
+  })
+})

--- a/lib/v2/components/Spinner/Spinner.tsx
+++ b/lib/v2/components/Spinner/Spinner.tsx
@@ -1,0 +1,16 @@
+import styles from './spinner.module.scss'
+
+const DOT_COUNT = 4
+
+export function Spinner() {
+  return (
+    <div className={styles.spinner}>
+      {Array.from({ length: DOT_COUNT }, (_, i) => (
+        <div
+          key={i}
+          className={styles.spinnerDot}
+        />
+      ))}
+    </div>
+  )
+}

--- a/lib/v2/components/Spinner/index.ts
+++ b/lib/v2/components/Spinner/index.ts
@@ -1,0 +1,1 @@
+export { Spinner } from './Spinner'

--- a/lib/v2/components/Spinner/spinner.module.scss
+++ b/lib/v2/components/Spinner/spinner.module.scss
@@ -1,0 +1,43 @@
+.spinner {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.spinnerDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--purple-500);
+  animation: spinner-pulse 1.4s ease-in-out infinite;
+
+  &:nth-child(1) {
+    animation-delay: -0.32s;
+  }
+
+  &:nth-child(2) {
+    animation-delay: -0.16s;
+  }
+
+  &:nth-child(3) {
+    animation-delay: 0s;
+  }
+
+  &:nth-child(4) {
+    animation-delay: 0.16s;
+  }
+}
+
+@keyframes spinner-pulse {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.7);
+    opacity: 0.5;
+  }
+
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/lib/v2/components/Table/FilterChips/FilterChips.tsx
+++ b/lib/v2/components/Table/FilterChips/FilterChips.tsx
@@ -223,8 +223,20 @@ function FilterChips({
         )
       case FILTER_TYPES.NUM_RANGE:
         return { compact: false, display: getNumRangeChip(filter) }
-      default:
+      default: {
+        const column = columns
+          ? findColumn([...columns], filter.columnId)
+          : undefined
+        const filterMeta = (
+          column as
+            | { meta?: { filter?: { uppercaseValue?: boolean } } }
+            | undefined
+        )?.meta?.filter
+        if (filterMeta?.uppercaseValue) {
+          return { compact: false, display: String(filter.value).toUpperCase() }
+        }
         return { compact: false, display: filter.value as string }
+      }
     }
   }
 

--- a/lib/v2/components/Table/FilterChips/filterChips.module.scss
+++ b/lib/v2/components/Table/FilterChips/filterChips.module.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/scrollbar' as *;
+
 .chipsContainer {
   display: flex;
   align-items: center;
@@ -165,28 +167,7 @@
   z-index: 100000;
   overflow: hidden auto;
 
-  &::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: var(--gray-100-900);
-    border-radius: 4px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--gray-400-600);
-    border-radius: 4px;
-    transition: background 0.2s ease;
-
-    &:hover {
-      background: var(--gray-500);
-    }
-  }
-
-  scrollbar-width: thin;
-  scrollbar-color: var(--gray-400-600) var(--gray-100-900);
+  @include thin-scrollbar;
 }
 
 .overlayContent {

--- a/lib/v2/components/Table/FilterPopover/FilterPopover.tsx
+++ b/lib/v2/components/Table/FilterPopover/FilterPopover.tsx
@@ -191,6 +191,17 @@ function FilterPopover({
     const selectChips = config.selectChips as Record<string, ReactNode>
     const hasCustomChips = selectChips && Object.keys(selectChips).length > 0
 
+    const renderSelectedContent = (): ReactNode => {
+      if (tempValue && selectChips?.[tempValue as string]) {
+        return selectChips[tempValue as string]
+      }
+      return (
+        <span className={styles.placeholder}>
+          {config.placeholder || SELECT_OPTION_PLACEHOLDER}
+        </span>
+      )
+    }
+
     if (hasCustomChips) {
       return (
         <div className={styles.customDropdownContainer}>
@@ -221,13 +232,7 @@ function FilterPopover({
             }}
           >
             <div className={styles.selectedOption}>
-              {tempValue && selectChips?.[tempValue as string] ? (
-                selectChips[tempValue as string]
-              ) : (
-                <span className={styles.placeholder}>
-                  {config.placeholder || SELECT_OPTION_PLACEHOLDER}
-                </span>
-              )}
+              {renderSelectedContent()}
             </div>
             <div className={styles.dropdownArrow}>
               <ChevronDownSmallIcon />
@@ -278,7 +283,8 @@ function FilterPopover({
         config.options?.length >= MIN_SEARCH_THRESHOLD) ||
       config.startWithSearch
 
-    const showOptionsImmediately = showOptionsList || !shouldShowSearch
+    const showOptionsImmediately =
+      config.startWithSearch || showOptionsList || !shouldShowSearch
 
     const getChipElement = (optionValue: string): ReactNode | null => {
       if (!config.selectChips || typeof config.selectChips !== 'object') {
@@ -419,6 +425,7 @@ function FilterPopover({
           <DateTimePicker
             enableCustomFormat
             maxDate={parseDateTime(dateValue.to) || DateTime.now()}
+            popperProps={{ placement: 'bottom-start' }}
             showSeconds={false}
             value={parseDateTime(dateValue.from)}
             onChange={(date?: DateTime) => {
@@ -435,6 +442,7 @@ function FilterPopover({
             enableCustomFormat
             maxDate={DateTime.now()}
             minDate={parseDateTime(dateValue.from)?.startOf('day')}
+            popperProps={{ placement: 'bottom-start' }}
             showSeconds={false}
             value={parseDateTime(dateValue.to)}
             onChange={(date?: DateTime) => {

--- a/lib/v2/components/Table/FilterPopover/filterPopover.module.scss
+++ b/lib/v2/components/Table/FilterPopover/filterPopover.module.scss
@@ -4,9 +4,7 @@
   left: 0;
   width: 250px;
   background: var(--gray-50-920);
-  box-shadow:
-    0 0 0 1px var(--gray-450-550),
-    0 8px 24px rgb(0 0 0 / 25%);
+  box-shadow: 0 0 0 1px var(--gray-450-550), 0 8px 24px rgb(0 0 0 / 25%);
   z-index: 10001;
   display: flex;
   flex-direction: column;
@@ -138,14 +136,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
+  padding: 4px 8px;
   border: 1px solid var(--gray-300-700);
   border-radius: 4px;
   background: var(--gray-50-950);
   color: var(--text-color-primary);
   cursor: pointer;
   transition: all 0.2s ease;
-  min-height: 40px;
+  min-height: 32px;
   position: relative;
 
   &:hover {
@@ -190,12 +188,12 @@
 }
 
 .customOption {
-  padding: 8px 12px;
+  padding: 4px 8px;
   cursor: pointer;
   transition: background-color 0.2s ease;
   display: flex;
   align-items: center;
-  min-height: 40px;
+  min-height: 32px;
 
   &:hover {
     background: var(--gray-100-850);

--- a/lib/v2/components/Table/SeverityCell/SeverityCell.stories.tsx
+++ b/lib/v2/components/Table/SeverityCell/SeverityCell.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { SEVERITY_TYPES } from '#v2/utils/consts'
+
+import { CellStoryTable } from '../CellStoryTable'
+import { SeverityCell } from './SeverityCell'
+
+const meta: Meta<typeof SeverityCell> = {
+  title: 'v2/Table/Cells/SeverityCell'
+}
+
+export default meta
+type Story = StoryObj<typeof SeverityCell>
+
+interface Row {
+  id: string
+  severity: string
+}
+
+const SAMPLE_ROWS: Row[] = [
+  { id: 'evt-1', severity: SEVERITY_TYPES.CRITICAL },
+  { id: 'evt-2', severity: SEVERITY_TYPES.MAJOR },
+  { id: 'evt-3', severity: SEVERITY_TYPES.MINOR },
+  { id: 'evt-4', severity: SEVERITY_TYPES.WARNING },
+  { id: 'evt-5', severity: SEVERITY_TYPES.INFO }
+]
+
+const columns: ColumnDef<Row, string>[] = [
+  {
+    accessorKey: 'severity',
+    header: 'Severity',
+    cell: SeverityCell,
+    size: 240
+  }
+]
+
+export const Interactive: Story = {
+  render: () => (
+    <CellStoryTable
+      columns={columns}
+      data={SAMPLE_ROWS}
+    />
+  )
+}

--- a/lib/v2/components/Table/SeverityCell/SeverityCell.test.tsx
+++ b/lib/v2/components/Table/SeverityCell/SeverityCell.test.tsx
@@ -1,0 +1,46 @@
+import type { CellContext } from '@tanstack/react-table'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SEVERITY_TYPES } from '#v2/utils/consts'
+
+import { SeverityCell } from './SeverityCell'
+
+interface TestRow {
+  id: string
+}
+
+const SAMPLE_ROW: TestRow = { id: 'r1' }
+
+function buildCellContext(value: string): CellContext<TestRow, string> {
+  return {
+    cell: { getValue: () => value },
+    row: { original: SAMPLE_ROW },
+    column: { columnDef: {} }
+  } as unknown as CellContext<TestRow, string>
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('SeverityCell', () => {
+  it('renders the severity label from the cell value', () => {
+    render(<SeverityCell {...buildCellContext(SEVERITY_TYPES.CRITICAL)} />)
+    expect(screen.getByText(SEVERITY_TYPES.CRITICAL)).toBeInTheDocument()
+  })
+
+  it('renders each severity value', () => {
+    for (const severity of [
+      SEVERITY_TYPES.MAJOR,
+      SEVERITY_TYPES.MINOR,
+      SEVERITY_TYPES.WARNING,
+      SEVERITY_TYPES.INFO
+    ]) {
+      cleanup()
+      render(<SeverityCell {...buildCellContext(severity)} />)
+      expect(screen.getByText(severity)).toBeInTheDocument()
+    }
+  })
+})

--- a/lib/v2/components/Table/SeverityCell/SeverityCell.tsx
+++ b/lib/v2/components/Table/SeverityCell/SeverityCell.tsx
@@ -1,0 +1,10 @@
+import type { CellContext } from '@tanstack/react-table'
+import type { Severity } from '#v2/utils/consts'
+
+import { SeverityChip } from '../../SeverityChip'
+
+export function SeverityCell<TData>({
+  cell
+}: Readonly<CellContext<TData, string>>) {
+  return <SeverityChip severity={cell.getValue() as Severity} />
+}

--- a/lib/v2/components/Table/SeverityCell/index.ts
+++ b/lib/v2/components/Table/SeverityCell/index.ts
@@ -1,0 +1,1 @@
+export { SeverityCell } from './SeverityCell'

--- a/lib/v2/components/Table/Table/EndlessScrollDemo.tsx
+++ b/lib/v2/components/Table/Table/EndlessScrollDemo.tsx
@@ -1,0 +1,91 @@
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { Table } from './Table'
+
+const REGIONS = ['us-east-1', 'us-west-2', 'eu-central-1']
+const STATUSES = ['Healthy', 'Degraded', 'Offline']
+const ENDLESS_BATCH_SIZE = 20
+const ENDLESS_LOAD_DELAY_MS = 800
+const ENDLESS_MAX_ITEMS = 100
+
+interface Cluster {
+  id: number
+  name: string
+  region: string
+  status: string
+}
+
+const COLUMNS: ColumnDef<Cluster>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'region', header: 'Region' },
+  { accessorKey: 'status', header: 'Status' }
+]
+
+const CONTAINER_STYLE = {
+  padding: 24,
+  background: 'var(--bg-secondary)',
+  height: 520
+}
+
+function makeItems(start: number, count: number): Cluster[] {
+  return Array.from({ length: count }, (_unused, i) => ({
+    id: start + i + 1,
+    name: `cluster-${start + i + 1}`,
+    region: REGIONS[(start + i) % REGIONS.length],
+    status: STATUSES[(start + i) % STATUSES.length]
+  }))
+}
+
+/**
+ * Storybook demo for the Table's endless-scroll mode.
+ * Simulates an API that returns pages of clusters, appending rows on scroll.
+ */
+export function EndlessScrollDemo() {
+  const [rows, setRows] = useState<Cluster[]>(() =>
+    makeItems(0, ENDLESS_BATCH_SIZE)
+  )
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const hasMore = rows.length < ENDLESS_MAX_ITEMS
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+      }
+    },
+    []
+  )
+
+  const handleLoadMore = useCallback(() => {
+    if (isLoadingMore) {
+      return
+    }
+    setIsLoadingMore(true)
+    timerRef.current = setTimeout(() => {
+      setRows((prev) => [
+        ...prev,
+        ...makeItems(prev.length, ENDLESS_BATCH_SIZE)
+      ])
+      setIsLoadingMore(false)
+    }, ENDLESS_LOAD_DELAY_MS)
+  }, [isLoadingMore])
+
+  return (
+    <div style={CONTAINER_STYLE}>
+      <Table
+        columns={COLUMNS}
+        data={rows}
+        endless
+        hasMore={hasMore}
+        isLoadingMore={isLoadingMore}
+        onLoadMore={handleLoadMore}
+        title={`Clusters (${rows.length} loaded${
+          hasMore ? ', scroll for more' : ' — all loaded'
+        })`}
+      />
+    </div>
+  )
+}

--- a/lib/v2/components/Table/Table/EndlessScrollExtras.tsx
+++ b/lib/v2/components/Table/Table/EndlessScrollExtras.tsx
@@ -1,0 +1,42 @@
+import type { RefObject } from 'react'
+
+import { Spinner } from '../../Spinner'
+
+import styles from './table.module.scss'
+
+interface EndlessScrollExtrasProps {
+  readonly endless: boolean
+  readonly isLoadingMore: boolean | undefined
+  readonly loading?: boolean
+  readonly sentinelRef: RefObject<HTMLDivElement>
+}
+
+/**
+ * Renders the sentinel div (observed by the IntersectionObserver in endless
+ * mode) and an optional loading indicator placed after the table body.
+ *
+ * When `endless` is false both elements are suppressed — this component is
+ * always mounted so the sentinel ref is always available for the observer hook,
+ * but it renders nothing unless the table is in endless-scroll mode.
+ */
+export function EndlessScrollExtras({
+  endless,
+  isLoadingMore,
+  loading = false,
+  sentinelRef
+}: EndlessScrollExtrasProps) {
+  if (!endless) {
+    return <div ref={sentinelRef} />
+  }
+
+  return (
+    <>
+      {isLoadingMore && !loading ? (
+        <div className={styles.endlessLoader}>
+          <Spinner />
+        </div>
+      ) : null}
+      <div ref={sentinelRef} />
+    </>
+  )
+}

--- a/lib/v2/components/Table/Table/Table.stories.tsx
+++ b/lib/v2/components/Table/Table/Table.stories.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react'
 import { FILTER_TYPES } from '#v2/utils/consts'
 
 import { Button } from '../../Button'
+import { EndlessScrollDemo } from './EndlessScrollDemo'
 import { Table } from './Table'
 import { TableWithDrawerDemo } from './TableWithDrawerDemo'
 
@@ -246,4 +247,8 @@ export const Framed: Story = {
       />
     </div>
   )
+}
+
+export const EndlessScroll: Story = {
+  render: () => <EndlessScrollDemo />
 }

--- a/lib/v2/components/Table/Table/Table.test.tsx
+++ b/lib/v2/components/Table/Table/Table.test.tsx
@@ -37,6 +37,7 @@ const FILTERABLE_COLUMNS: ColumnDef<Item>[] = [
 const RESIZER_ID_TESTID = 'column-resizer-id'
 const RESIZER_NAME_TESTID = 'column-resizer-name'
 const ROW_ACTIONS_BUTTON_TESTID = 'row-actions-button'
+const EMPTY_MESSAGE = 'No items found'
 
 describe('Table', () => {
   describe('baseline functionality', () => {
@@ -59,13 +60,26 @@ describe('Table', () => {
         <Table
           columns={COLUMNS}
           data={[]}
-          emptyMessage='No items found'
+          emptyMessage={EMPTY_MESSAGE}
         />
       )
-      expect(screen.getByText('No items found')).toBeInTheDocument()
+      expect(screen.getByText(EMPTY_MESSAGE)).toBeInTheDocument()
     })
 
-    it('renders the loading state', () => {
+    it('renders the loading state with spinner and suppresses row data', () => {
+      const { container } = render(
+        <Table
+          columns={COLUMNS}
+          data={DATA}
+          loading
+        />
+      )
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+      expect(screen.queryByText('Item 1')).not.toBeInTheDocument()
+      expect(container.querySelector('[class*="spinner"]')).toBeInTheDocument()
+    })
+
+    it('shows column headers when loading', () => {
       render(
         <Table
           columns={COLUMNS}
@@ -73,7 +87,31 @@ describe('Table', () => {
           loading
         />
       )
-      expect(screen.getByText('Loading...')).toBeInTheDocument()
+      expect(screen.getByText('ID')).toBeInTheDocument()
+      expect(screen.getByText('Name')).toBeInTheDocument()
+    })
+
+    it('suppresses empty state while loading even with empty data', () => {
+      render(
+        <Table
+          columns={COLUMNS}
+          data={[]}
+          emptyMessage={EMPTY_MESSAGE}
+          loading
+        />
+      )
+      expect(screen.queryByText(EMPTY_MESSAGE)).not.toBeInTheDocument()
+    })
+
+    it('shows empty state when not loading and data is empty', () => {
+      render(
+        <Table
+          columns={COLUMNS}
+          data={[]}
+          emptyMessage={EMPTY_MESSAGE}
+        />
+      )
+      expect(screen.getByText(EMPTY_MESSAGE)).toBeInTheDocument()
     })
   })
 

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -19,16 +19,19 @@ import clsx from 'clsx'
 import { EMPTY_STRING } from '#consts'
 import { NOOP } from '#v2/utils/consts'
 
+import { Spinner } from '../../Spinner'
 import { Pagination } from '../Pagination'
 import { RowActionsCell } from '../RowActionsCell'
 import { TableFilter } from '../TableFilter'
 import { buildTableColumns, getCanShowFilter } from '../tableUtils'
 import { useColumnVisibility } from './hooks/useColumnVisibility'
+import { useEndlessScroll } from './hooks/useEndlessScroll'
 import { useGlobalSearch } from './hooks/useGlobalSearch'
 import { useInitialSorting } from './hooks/useInitialSorting'
 import { usePaginationState } from './hooks/usePaginationState'
 import { useScrollToRow } from './hooks/useScrollToRow'
 import { useTableOptions } from './hooks/useTableOptions'
+import { EndlessScrollExtras } from './EndlessScrollExtras'
 import { renderTableBody } from './renderTableBody'
 import { TableContent } from './TableContent'
 import { TableHeaderSection } from './TableHeaderSection'
@@ -77,6 +80,7 @@ export interface TableProps<TData = unknown> {
   showSearch?: boolean
 
   manualPagination?: boolean
+  manualFiltering?: boolean
   itemsAmount?: number
   fixedPageSize?: number
   pageSize?: number
@@ -111,6 +115,10 @@ export interface TableProps<TData = unknown> {
   drawerWidth?: number
   framed?: boolean
   rowActionsWidth?: number
+  endless?: boolean
+  hasMore?: boolean
+  isLoadingMore?: boolean
+  onLoadMore?: () => void
 }
 
 export const ROW_ACTIONS_COLUMN_ID = '__rowActions__'
@@ -129,6 +137,7 @@ export function Table<TData = unknown>({
   emptyMessage = 'No data',
   maxHeight,
   manualPagination,
+  manualFiltering,
   itemsAmount,
   fixedPageSize,
   onPaginationChange,
@@ -169,7 +178,11 @@ export function Table<TData = unknown>({
   drawerOpen = false,
   drawerWidth = 0,
   framed = false,
-  rowActionsWidth = ROW_ACTIONS_COLUMN_SIZE
+  rowActionsWidth = ROW_ACTIONS_COLUMN_SIZE,
+  endless = false,
+  hasMore,
+  isLoadingMore,
+  onLoadMore
 }: Readonly<TableProps<TData>>) {
   const { columnVisibility, handleColumnVisibilityChange } =
     useColumnVisibility({
@@ -215,6 +228,7 @@ export function Table<TData = unknown>({
 
   const headerRef = useRef<HTMLDivElement>(null)
   const bodyRef = useRef<HTMLDivElement>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
 
   const handleBodyScroll = () => {
     if (headerRef.current && bodyRef.current) {
@@ -289,6 +303,7 @@ export function Table<TData = unknown>({
     currentPage,
     effectivePageSize,
     manualPagination,
+    manualFiltering,
     manualSorting
   })
 
@@ -345,7 +360,8 @@ export function Table<TData = unknown>({
     filteredRowCount
   ])
 
-  const visibleRowCount = table.getRowModel().rows.length
+  const paginatedRows = table.getRowModel().rows
+  const visibleRowCount = paginatedRows.length
 
   const isCompactTable = useMemo(() => {
     if (loading || maxHeight || visibleRowCount === 0) {
@@ -370,6 +386,21 @@ export function Table<TData = unknown>({
     effectivePageSize,
     showPagination
   ])
+
+  const { displayRows, effectiveIsCompact, effectiveShowPagination } =
+    useEndlessScroll({
+      endless,
+      hasMore,
+      isLoadingMore,
+      loading,
+      onLoadMore,
+      paginatedRows,
+      sentinelRef,
+      showPagination,
+      scrollContainerRef: bodyRef,
+      isCompact: isCompactTable,
+      prePaginationRows: table.getPrePaginationRowModel().rows
+    })
 
   useEffect(() => {
     if (!onFilteredDataChange) {
@@ -403,17 +434,6 @@ export function Table<TData = unknown>({
       }
     : undefined
 
-  if (loading) {
-    return (
-      <div
-        className={styles.customTableWrapper}
-        style={wrapperStyle}
-      >
-        <div className={styles.loadingState}>Loading...</div>
-      </div>
-    )
-  }
-
   const handleResetColumnSizing = () => {
     table.getAllColumns().forEach((column) => column.resetSize())
     onResetColumnSizing?.()
@@ -440,7 +460,7 @@ export function Table<TData = unknown>({
       style={wrapperStyle}
       className={clsx(
         styles.customTableWrapper,
-        isCompactTable && styles.compactTable,
+        effectiveIsCompact && styles.compactTable,
         isFetching && styles.fetching
       )}
     >
@@ -452,6 +472,7 @@ export function Table<TData = unknown>({
         customFilters={customFilters}
         customTitle={customTitle}
         data={data}
+        endless={endless}
         getCsvData={getCsvData}
         onClearAllFilters={handleClearAllFilters}
         onCsvError={onCsvError}
@@ -474,7 +495,7 @@ export function Table<TData = unknown>({
         framed,
         footer: (
           <div className={styles.tableFooter}>
-            {showPagination ? (
+            {effectiveShowPagination ? (
               <Pagination
                 currentPage={currentPage}
                 isPageEnabled={isPaginationPageEnabled}
@@ -576,8 +597,9 @@ export function Table<TData = unknown>({
                     activeRowId={activeRowId}
                     emptyMessage={emptyMessage}
                     getRowId={getRowId}
+                    loading={loading}
                     onRowClick={onRowClick}
-                    rows={table.getRowModel().rows}
+                    rows={displayRows}
                     renderCell={(cell) => {
                       const cellMeta = cell.column.columnDef.meta as
                         | { cellStyle?: CSSProperties }
@@ -607,6 +629,17 @@ export function Table<TData = unknown>({
                   />
                 </tbody>
               </table>
+              {loading ? (
+                <div className={styles.bodyLoaderInner}>
+                  <Spinner />
+                </div>
+              ) : null}
+              <EndlessScrollExtras
+                endless={endless}
+                isLoadingMore={isLoadingMore}
+                loading={loading}
+                sentinelRef={sentinelRef}
+              />
             </div>
           </div>
         )

--- a/lib/v2/components/Table/Table/TableContent/TableContent.tsx
+++ b/lib/v2/components/Table/Table/TableContent/TableContent.tsx
@@ -12,6 +12,7 @@ const ROW_PARITY_DIVISOR = 2
 export interface TableContentProps<TData> {
   rows: Row<TData>[]
   emptyMessage: string
+  loading?: boolean
   onRowClick?: (row: TData) => void
   activeRowId?: string | number
   getRowId?: (row: TData) => string | number | null | undefined
@@ -21,11 +22,16 @@ export interface TableContentProps<TData> {
 export function TableContent<TData>({
   rows,
   emptyMessage,
+  loading = false,
   onRowClick,
   activeRowId,
   getRowId,
   renderCell
 }: Readonly<TableContentProps<TData>>) {
+  if (loading) {
+    return null
+  }
+
   if (rows.length === 0) {
     return (
       <tr>

--- a/lib/v2/components/Table/Table/TableHeaderSection/TableHeaderSection.tsx
+++ b/lib/v2/components/Table/Table/TableHeaderSection/TableHeaderSection.tsx
@@ -33,6 +33,26 @@ export interface TableHeaderSectionProps<TData> {
   onGlobalSearch: (searchTerm: string) => void
   onRemoveFilter: (columnId: string) => void
   onResetColumnSizing: () => void
+  endless?: boolean
+}
+
+function renderTitleSection(
+  title: string | undefined,
+  customTitle: ReactNode,
+  actualFilteredCount: number,
+  endless: boolean
+): ReactNode {
+  if (customTitle) {
+    return <div className={styles.customTitle}>{customTitle}</div>
+  }
+  return (
+    <>
+      <h3 className={styles.tableTitle}>{title}</h3>
+      {!endless && actualFilteredCount > 0 ? (
+        <span className={styles.tableCount}>({actualFilteredCount})</span>
+      ) : null}
+    </>
+  )
 }
 
 export function TableHeaderSection<TData>({
@@ -56,7 +76,8 @@ export function TableHeaderSection<TData>({
   onFilterChange,
   onGlobalSearch,
   onRemoveFilter,
-  onResetColumnSizing
+  onResetColumnSizing,
+  endless = false
 }: Readonly<TableHeaderSectionProps<TData>>) {
   const hasTitle = Boolean(title || customTitle)
   const hasActiveFilters = activeFilters.length > 0
@@ -72,6 +93,7 @@ export function TableHeaderSection<TData>({
         customFilters={customFilters}
         customTitle={customTitle}
         data={data}
+        endless={endless}
         getCsvData={getCsvData}
         onClearAllFilters={onClearAllFilters}
         onCsvError={onCsvError}
@@ -96,18 +118,7 @@ export function TableHeaderSection<TData>({
     <div className={styles.tableHeader}>
       <div className={styles.titleRow}>
         <div className={styles.titleSection}>
-          {customTitle ? (
-            <div className={styles.customTitle}>{customTitle}</div>
-          ) : (
-            <>
-              <h3 className={styles.tableTitle}>{title}</h3>
-              {actualFilteredCount > 0 && (
-                <span className={styles.tableCount}>
-                  ({actualFilteredCount})
-                </span>
-              )}
-            </>
-          )}
+          {renderTitleSection(title, customTitle, actualFilteredCount, endless)}
         </div>
         {showFilterChips && hasActiveFilters ? (
           <FilterChips

--- a/lib/v2/components/Table/Table/endless.test.tsx
+++ b/lib/v2/components/Table/Table/endless.test.tsx
@@ -1,0 +1,283 @@
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Table } from './Table'
+
+interface Item {
+  id: number
+  name: string
+}
+
+const COLUMNS: ColumnDef<Item>[] = [
+  { id: 'id', accessorKey: 'id', header: 'ID' },
+  { id: 'name', accessorKey: 'name', header: 'Name' }
+]
+
+const SMALL_SET = 5
+const MEDIUM_SET = 30
+const LARGE_SET = 50
+const SMALL_PAGE_SIZE = 10
+const makeData = (count: number): Item[] =>
+  Array.from({ length: count }, (_unused, i) => ({
+    id: i + 1,
+    name: `Item ${i + 1}`
+  }))
+
+/**
+ * Minimal IntersectionObserver stub that can be used with `new`.
+ * Captures the latest callback so tests can invoke it directly to simulate
+ * intersection events without a real browser layout engine.
+ */
+type IOHandler = (entries: IntersectionObserverEntry[]) => void
+
+let observerCallback: IOHandler | null = null
+
+class FakeIntersectionObserver {
+  constructor(handler: IOHandler) {
+    observerCallback = handler
+  }
+
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+
+const triggerIntersection = (isIntersecting: boolean) => {
+  observerCallback?.([{ isIntersecting } as IntersectionObserverEntry])
+}
+
+interface LoadMoreOverrides {
+  endless?: boolean
+  hasMore?: boolean
+  isLoadingMore?: boolean
+  loading?: boolean
+  rowCount?: number
+}
+
+const endlessTable = (
+  onLoadMore: () => void,
+  { rowCount = SMALL_SET, ...overrides }: LoadMoreOverrides = {}
+) => (
+  <Table
+    columns={COLUMNS}
+    data={makeData(rowCount)}
+    endless
+    hasMore
+    isLoadingMore={false}
+    onLoadMore={onLoadMore}
+    {...overrides}
+  />
+)
+
+const renderForLoadMore = (
+  onLoadMore: () => void,
+  overrides: LoadMoreOverrides = {}
+) => render(endlessTable(onLoadMore, overrides))
+
+beforeEach(() => {
+  observerCallback = null
+  vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('Table endless-scroll mode', () => {
+  describe('row rendering', () => {
+    it('renders all rows without pagination slicing when endless is true', () => {
+      const data = makeData(MEDIUM_SET)
+      render(
+        <Table
+          columns={COLUMNS}
+          data={data}
+          endless
+          pageSize={SMALL_PAGE_SIZE}
+        />
+      )
+      expect(screen.getByText(`Item ${MEDIUM_SET}`)).toBeInTheDocument()
+      expect(screen.getByText('Item 1')).toBeInTheDocument()
+    })
+
+    it('respects pagination (does NOT show page-2 rows) when endless is false', () => {
+      const data = makeData(MEDIUM_SET)
+      render(
+        <Table
+          columns={COLUMNS}
+          data={data}
+          pageSize={SMALL_PAGE_SIZE}
+        />
+      )
+      expect(
+        screen.queryByText(`Item ${SMALL_PAGE_SIZE + 1}`)
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('pagination footer', () => {
+    it('does not render Pagination when endless is true and there are many rows', () => {
+      const data = makeData(LARGE_SET)
+      const { container } = render(
+        <Table
+          columns={COLUMNS}
+          data={data}
+          endless
+          pageSize={SMALL_PAGE_SIZE}
+        />
+      )
+      const footer = container.querySelector('.tableFooter')
+      const pageButtons = footer?.querySelectorAll('button')
+      expect(pageButtons?.length).toBe(0)
+    })
+  })
+
+  describe('IntersectionObserver — onLoadMore', () => {
+    it('calls onLoadMore when sentinel intersects with hasMore=true and not loading', () => {
+      const onLoadMore = vi.fn()
+      renderForLoadMore(onLoadMore)
+      triggerIntersection(true)
+      expect(onLoadMore).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onLoadMore when hasMore is false', () => {
+      const onLoadMore = vi.fn()
+      renderForLoadMore(onLoadMore, { hasMore: false })
+      triggerIntersection(true)
+      expect(onLoadMore).not.toHaveBeenCalled()
+    })
+
+    it('does not call onLoadMore while the initial query is loading', () => {
+      const onLoadMore = vi.fn()
+      renderForLoadMore(onLoadMore, { loading: true })
+      triggerIntersection(true)
+      expect(onLoadMore).not.toHaveBeenCalled()
+    })
+
+    it('calls onLoadMore only once when the sentinel intersects repeatedly before the loading flag updates', () => {
+      const onLoadMore = vi.fn()
+      renderForLoadMore(onLoadMore)
+      triggerIntersection(true)
+      triggerIntersection(true)
+      triggerIntersection(true)
+      expect(onLoadMore).toHaveBeenCalledTimes(1)
+    })
+
+    it('loads the next page after a load-more cycle completes', () => {
+      const onLoadMore = vi.fn()
+      const { rerender } = render(endlessTable(onLoadMore))
+      triggerIntersection(true)
+      expect(onLoadMore).toHaveBeenCalledTimes(1)
+
+      rerender(endlessTable(onLoadMore, { isLoadingMore: true }))
+      rerender(endlessTable(onLoadMore, { rowCount: SMALL_SET * 2 }))
+      triggerIntersection(true)
+      expect(onLoadMore).toHaveBeenCalledTimes(2)
+    })
+
+    it('stays unblocked after a load that returns no new rows', () => {
+      const onLoadMore = vi.fn()
+      const { rerender } = render(endlessTable(onLoadMore))
+      triggerIntersection(true)
+      expect(onLoadMore).toHaveBeenCalledTimes(1)
+
+      rerender(endlessTable(onLoadMore, { isLoadingMore: true }))
+      rerender(endlessTable(onLoadMore))
+      triggerIntersection(true)
+      expect(onLoadMore).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not call onLoadMore when isLoadingMore is true', () => {
+      const onLoadMore = vi.fn()
+      renderForLoadMore(onLoadMore, { isLoadingMore: true })
+      triggerIntersection(true)
+      expect(onLoadMore).not.toHaveBeenCalled()
+    })
+
+    it('does not call onLoadMore when sentinel is not intersecting', () => {
+      const onLoadMore = vi.fn()
+      renderForLoadMore(onLoadMore)
+      triggerIntersection(false)
+      expect(onLoadMore).not.toHaveBeenCalled()
+    })
+
+    it('does not fire onLoadMore when endless is false (observer not set up)', () => {
+      const onLoadMore = vi.fn()
+      renderForLoadMore(onLoadMore, { endless: false })
+      triggerIntersection(true)
+      expect(onLoadMore).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('loading indicator', () => {
+    it('shows spinner (no text) when isLoadingMore is true in endless mode', () => {
+      const { container } = render(
+        <Table
+          columns={COLUMNS}
+          data={makeData(SMALL_SET)}
+          endless
+          isLoadingMore
+        />
+      )
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+      expect(container.querySelector('[class*="spinner"]')).toBeInTheDocument()
+    })
+
+    it('does not show spinner when isLoadingMore is false in endless mode', () => {
+      const { container } = render(
+        <Table
+          columns={COLUMNS}
+          data={makeData(SMALL_SET)}
+          endless
+          isLoadingMore={false}
+        />
+      )
+      expect(screen.getByText('Item 1')).toBeInTheDocument()
+      expect(
+        container.querySelector('[class*="endlessLoader"]')
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not show endless spinner when not in endless mode', () => {
+      const { container } = render(
+        <Table
+          columns={COLUMNS}
+          data={makeData(SMALL_SET)}
+          isLoadingMore
+        />
+      )
+      expect(
+        container.querySelector('[class*="endlessLoader"]')
+      ).not.toBeInTheDocument()
+    })
+
+    it('suppresses empty state and shows spinner when loading=true with empty data in endless mode', () => {
+      const { container } = render(
+        <Table
+          columns={COLUMNS}
+          data={[]}
+          endless
+          loading
+        />
+      )
+      expect(
+        screen.queryByTestId('table-empty-message')
+      ).not.toBeInTheDocument()
+      expect(
+        container.querySelector('[class*="bodyLoader"]')
+      ).toBeInTheDocument()
+    })
+
+    it('shows empty state (not spinner) when loading=false and data=[] in endless mode', () => {
+      render(
+        <Table
+          columns={COLUMNS}
+          data={[]}
+          endless
+        />
+      )
+      expect(screen.getByTestId('table-empty-message')).toBeInTheDocument()
+    })
+  })
+})

--- a/lib/v2/components/Table/Table/endlessScroll.test.ts
+++ b/lib/v2/components/Table/Table/endlessScroll.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldLoadMore } from './endlessScroll'
+
+describe('shouldLoadMore', () => {
+  it('returns true when intersecting, hasMore, and not loading', () => {
+    expect(shouldLoadMore(true, true, false, false)).toBe(true)
+  })
+
+  it('returns false when not intersecting', () => {
+    expect(shouldLoadMore(false, true, false, false)).toBe(false)
+  })
+
+  it('returns false when hasMore is false', () => {
+    expect(shouldLoadMore(true, false, false, false)).toBe(false)
+  })
+
+  it('returns false when isLoadingMore is true', () => {
+    expect(shouldLoadMore(true, true, true, false)).toBe(false)
+  })
+
+  it('returns false when the initial query is loading', () => {
+    expect(shouldLoadMore(true, true, false, true)).toBe(false)
+  })
+
+  it('returns false when hasMore is undefined', () => {
+    expect(shouldLoadMore(true, undefined, false, false)).toBe(false)
+  })
+
+  it('returns true when isLoadingMore and isLoading are undefined (falsy)', () => {
+    expect(shouldLoadMore(true, true, undefined, undefined)).toBe(true)
+  })
+
+  it('returns false when all args are false / undefined', () => {
+    expect(shouldLoadMore(false, false, false, false)).toBe(false)
+  })
+})

--- a/lib/v2/components/Table/Table/endlessScroll.ts
+++ b/lib/v2/components/Table/Table/endlessScroll.ts
@@ -1,0 +1,23 @@
+/**
+ * Helpers for the Table component's endless-scroll (infinite-scroll) mode.
+ */
+
+/**
+ * Returns true when the IntersectionObserver callback should trigger a
+ * load-more request. All conditions must hold simultaneously:
+ *   - the sentinel element is intersecting the scroll viewport
+ *   - there are more rows to load (`hasMore`)
+ *   - a previous page load is not already in flight (`isLoadingMore`)
+ *   - the initial/full-table query is not in flight (`isLoading`)
+ *
+ * The `isLoading` guard prevents requesting page 2 while the first query is
+ * still resolving (empty or stale rows with the sentinel already in view).
+ */
+export function shouldLoadMore(
+  isIntersecting: boolean,
+  hasMore: boolean | undefined,
+  isLoadingMore: boolean | undefined,
+  isLoading: boolean | undefined
+): boolean {
+  return isIntersecting && !!hasMore && !isLoadingMore && !isLoading
+}

--- a/lib/v2/components/Table/Table/hooks/useEndlessScroll.ts
+++ b/lib/v2/components/Table/Table/hooks/useEndlessScroll.ts
@@ -1,0 +1,113 @@
+import type { Row } from '@tanstack/react-table'
+import type { RefObject } from 'react'
+
+import { useEffect, useRef } from 'react'
+
+import { shouldLoadMore } from '../endlessScroll'
+
+interface UseEndlessScrollParams<TData> {
+  endless: boolean
+  hasMore: boolean | undefined
+  isLoadingMore: boolean | undefined
+  loading: boolean | undefined
+  onLoadMore: (() => void) | undefined
+  sentinelRef: RefObject<HTMLDivElement>
+  scrollContainerRef: RefObject<HTMLDivElement>
+  paginatedRows: Row<TData>[]
+  prePaginationRows: Row<TData>[]
+  isCompact: boolean
+  showPagination: boolean
+}
+
+interface UseEndlessScrollResult<TData> {
+  displayRows: Row<TData>[]
+  effectiveIsCompact: boolean
+  effectiveShowPagination: boolean
+}
+
+/**
+ * Wires an IntersectionObserver on `sentinelRef` (root = `scrollContainerRef`)
+ * and calls `onLoadMore` whenever the sentinel enters the viewport, `hasMore`
+ * is true, and neither `isLoadingMore` nor `loading` is in flight.
+ *
+ * A ref guard (`loadRequestedRef`) makes each request fire at most once: it is
+ * set synchronously when `onLoadMore` is called — so rapid intersection
+ * callbacks that fire before the parent re-renders with the new loading flag
+ * cannot trigger duplicate requests — and reset when the parent acknowledges
+ * the request (`isLoadingMore` turns true), so the next page can load once the
+ * current one settles. Tying the reset to `isLoadingMore` rather than the row
+ * count keeps client-side filtering from clearing the guard and still recovers
+ * from loads that return no new rows.
+ *
+ * Also derives display-ready values so the Table component itself remains free
+ * of conditional branches for endless-mode overrides:
+ * - `displayRows` — all pre-pagination rows when endless, paginated otherwise
+ * - `effectiveIsCompact` — always false in endless mode
+ * - `effectiveShowPagination` — always false in endless mode
+ */
+export function useEndlessScroll<TData>({
+  endless,
+  hasMore,
+  isLoadingMore,
+  loading,
+  onLoadMore,
+  sentinelRef,
+  scrollContainerRef,
+  paginatedRows,
+  prePaginationRows,
+  isCompact,
+  showPagination
+}: UseEndlessScrollParams<TData>): UseEndlessScrollResult<TData> {
+  const loadRequestedRef = useRef(false)
+
+  useEffect(() => {
+    if (isLoadingMore) {
+      loadRequestedRef.current = false
+    }
+  }, [isLoadingMore])
+
+  useEffect(() => {
+    if (!endless) {
+      return undefined
+    }
+    const sentinel = sentinelRef.current
+    const root = scrollContainerRef.current
+    if (!sentinel || !root) {
+      return undefined
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (
+          entry &&
+          shouldLoadMore(
+            entry.isIntersecting,
+            hasMore,
+            isLoadingMore,
+            loading
+          ) &&
+          !loadRequestedRef.current
+        ) {
+          loadRequestedRef.current = true
+          onLoadMore?.()
+        }
+      },
+      { root }
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [
+    endless,
+    hasMore,
+    isLoadingMore,
+    loading,
+    onLoadMore,
+    sentinelRef,
+    scrollContainerRef
+  ])
+
+  return {
+    displayRows: endless ? prePaginationRows : paginatedRows,
+    effectiveIsCompact: endless ? false : isCompact,
+    effectiveShowPagination: endless ? false : showPagination
+  }
+}

--- a/lib/v2/components/Table/Table/hooks/useTableOptions.ts
+++ b/lib/v2/components/Table/Table/hooks/useTableOptions.ts
@@ -37,6 +37,7 @@ interface UseTableOptionsParams<TData> {
   currentPage: number
   effectivePageSize: number
   manualPagination: boolean | undefined
+  manualFiltering?: boolean
   manualSorting?: boolean
 }
 
@@ -58,6 +59,7 @@ export function useTableOptions<TData>({
   currentPage,
   effectivePageSize,
   manualPagination,
+  manualFiltering,
   manualSorting
 }: UseTableOptionsParams<TData>) {
   return useMemo(() => {
@@ -87,6 +89,7 @@ export function useTableOptions<TData>({
       ...(manualSorting ? {} : { getSortedRowModel: getSortedRowModel() }),
       getFilteredRowModel: getFilteredRowModel(),
       columnResizeMode,
+      manualFiltering,
       manualSorting
     }
 
@@ -116,6 +119,7 @@ export function useTableOptions<TData>({
     currentPage,
     effectivePageSize,
     manualPagination,
+    manualFiltering,
     manualSorting
   ])
 }

--- a/lib/v2/components/Table/Table/table.module.scss
+++ b/lib/v2/components/Table/Table/table.module.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/scrollbar' as *;
+
 .customTableWrapper {
   width: 100%;
   height: 100%;
@@ -118,28 +120,7 @@
   min-height: 0;
   position: relative;
 
-  &::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: var(--gray-100-900);
-    border-radius: 4px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--gray-400-600);
-    border-radius: 4px;
-    transition: background 0.2s ease;
-
-    &:hover {
-      background: var(--gray-500);
-    }
-  }
-
-  scrollbar-width: thin;
-  scrollbar-color: var(--gray-400-600) var(--gray-100-900);
+  @include thin-scrollbar;
 
   .table {
     border-top: none;
@@ -390,6 +371,23 @@ thead.tableHeader {
   padding: 48px;
   color: var(--gray-600-400);
   font-size: 16px;
+  background-color: var(--gray-50-920);
+}
+
+.bodyLoaderInner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--gray-50-920);
+}
+
+.endlessLoader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
   background-color: var(--gray-50-920);
 }
 

--- a/lib/v2/components/Table/TableHeader/TableHeader.tsx
+++ b/lib/v2/components/Table/TableHeader/TableHeader.tsx
@@ -58,6 +58,7 @@ export interface TableHeaderProps<TData = unknown> {
   title: string
   customTitle?: ReactNode
   count?: number
+  endless?: boolean
   activeFilters?: readonly ActiveFilter[]
   onRemoveFilter?: (columnId: string) => void
   onClearAllFilters?: () => void
@@ -169,6 +170,7 @@ export function TableHeader({
   customTitle,
   csvFileTitle,
   count,
+  endless = false,
   activeFilters = EMPTY_ARRAY,
   onRemoveFilter,
   onClearAllFilters,
@@ -431,7 +433,7 @@ export function TableHeader({
         >
           {title}
         </h2>
-        {renderCount()}
+        {endless ? null : renderCount()}
       </>
     )
   }

--- a/lib/v2/components/Table/filterUtils.ts
+++ b/lib/v2/components/Table/filterUtils.ts
@@ -35,6 +35,7 @@ export interface FilterConfig {
   startWithSearch?: boolean
   title?: string
   modeLabels?: { used?: string; total?: string }
+  uppercaseValue?: boolean
 }
 
 /** An applied filter for a column */
@@ -54,6 +55,7 @@ export interface FilterMeta {
   selectChips?: Record<string, ReactNode> | ReactNode[]
   startWithSearch?: boolean
   modeLabels?: { used?: string; total?: string }
+  uppercaseValue?: boolean
 }
 
 /** Column definition with optional filter metadata */
@@ -214,7 +216,8 @@ export function createDropdownFilter(
       ? `Select ${filterMeta.title}...`
       : `Select ${columnId}...`,
     title: filterMeta.title,
-    selectChips: filterMeta.selectChips
+    selectChips: filterMeta.selectChips,
+    uppercaseValue: filterMeta.uppercaseValue
   }
 }
 

--- a/lib/v2/components/index.ts
+++ b/lib/v2/components/index.ts
@@ -184,6 +184,7 @@ export {
   SimpleTable,
   useExpandableTextContext
 } from './SimpleTable'
+export { Spinner } from './Spinner'
 export {
   STAT_BOX_STATUS,
   STAT_COLOR_VARIANT,
@@ -292,6 +293,7 @@ export {
   REDUCTION_RANGE_MODES,
   ReductionRangeFilter
 } from './Table/ReductionRangeFilter'
+export { SeverityCell } from './Table/SeverityCell'
 export type {
   StatusCellOptions,
   StatusCellValue,

--- a/lib/v2/styles/_scrollbar.scss
+++ b/lib/v2/styles/_scrollbar.scss
@@ -1,0 +1,24 @@
+@mixin thin-scrollbar {
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: var(--gray-100-900);
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--gray-400-600);
+    border-radius: 4px;
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: var(--gray-500);
+    }
+  }
+
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-400-600) var(--gray-100-900);
+}

--- a/lib/v2/styles/theme.scss
+++ b/lib/v2/styles/theme.scss
@@ -147,7 +147,11 @@
   --peach-600-400: #{$peach-600};
   --peach-800-200: #{$peach-800};
 
+  // Blue Theme Variables
+  --blue-300-700: #{$blue-300};
+
   // Aqua Theme Variables
+  --aqua-300-700: #{$aqua-300};
   --aqua-500: #{$aqua-500};
   --aqua-600-400: #{$aqua-600};
 
@@ -368,7 +372,11 @@
   --peach-600-400: #{$peach-400};
   --peach-800-200: #{$peach-200};
 
+  // Blue Theme Variables
+  --blue-300-700: #{$blue-700};
+
   // Aqua Theme Variables
+  --aqua-300-700: #{$aqua-700};
   --aqua-500: #{$aqua-500};
   --aqua-600-400: #{$aqua-400};
 


### PR DESCRIPTION
## Summary

v2 Table gains **endless-scroll**, an **in-frame loading state**, and **manual (server-side) filtering**, plus a batch of DateTimePicker dark-mode fixes and severity/filter refinements. Driven by the NeuralMesh Events page (server-paginated, endless) in wekapp.

## Table
- **Endless-scroll** (infinite scroll) mode — IntersectionObserver sentinel + `useEndlessScroll`; auto-fetches while `hasMore`.
- **In-frame loading** (`loading` prop) — a centered spinner overlay inside the table body; the frame (title + column headers) stays mounted. "No data" only shows once the query settles empty (never during load).
- **Shared `Spinner`** component — deduped across `TableContent`, `EndlessScrollExtras`, and `LoadingState`.
- **`manualFiltering`** prop — for server-filtered tables; skips client-side re-filtering (`activeFilters` still drive chips + `onFiltersChange`). Global search is unaffected (it pre-filters the data array).
- **Full-width header** — `scrollbar-gutter: stable` instead of a JS scrollbar-gutter pad; extracted a scrollbar mixin.
- **`SeverityCell`** — cell renderer that renders the lib `SeverityChip` from the cell value.

## Filters
- Dropdown filter config: `title` (popover header), `startWithSearch` (show the full options list on open + narrow via search), `uppercaseValue` (render the value uppercase in the chip bar).
- Collapsed selected value keeps the `SeverityChip`; the options list still renders chips.

## SeverityChip
- `border-radius: 2px` to match the design system (was a stray `20px`).

## DateTimePicker (dark mode)
- Calendar text color, month/year label, and time-input background now use theme tokens.
- Day cells derive muted colors from the **inherited** text color via opacity (works regardless of the portal/theme scope); split **out-of-bounds** (min/max) vs **outside-month** styling.
- Popper `z-index` / `placement` / `fixed` strategy so the calendar anchors to its field and layers above filter popovers.

## Theme
- Added `--blue-300-700` and `--aqua-300-700` pair tokens.

## Versioning
No `patch` label → auto-release will publish a **minor** bump (4.36.0 → 4.37.0), which is appropriate (additive features, backward-compatible).

## Verification
- `eslint` (diff config): clean
- `test:run`: **1238 tests pass** (115 files)
- `build`: ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
