### PR TITLE
fix(v2): Table horizontal scroll in compact and empty states

### DIFF
--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -512,7 +512,10 @@ export function Table<TData = unknown>({
               ref={headerRef}
               className={styles.tableHeaderWrapper}
             >
-              <table className={styles.table}>
+              <table
+                className={styles.table}
+                style={{ minWidth: table.getTotalSize() }}
+              >
                 <thead className={styles.tableHeader}>
                   {table.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id}>
@@ -592,6 +595,7 @@ export function Table<TData = unknown>({
               <table
                 className={styles.table}
                 data-testid={dataTestId}
+                style={{ minWidth: table.getTotalSize() }}
               >
                 <tbody className={styles.tableBody}>
                   <TableContent

--- a/lib/v2/components/Table/Table/table.module.scss
+++ b/lib/v2/components/Table/Table/table.module.scss
@@ -29,7 +29,6 @@
 
         .tableWrapper {
           flex: none;
-          overflow: visible;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fix Table losing its horizontal scrollbar in **compact mode** (fewer rows than page size): the compact override set the body wrapper to `overflow: visible`, so wide tables were clipped by the container's `overflow: hidden` with no way to scroll. Keeps the base `overflow: auto` in compact mode.
- Fix **empty tables** being unable to scroll horizontally: the empty-state row is a single `colspan` cell with no width, so the body table never grew past the container while the wider header sat clipped. Both header and body tables now get `minWidth: table.getTotalSize()` so they span the full column width and the body scrollbar reveals every column.

## Release
Labeled `patch` → CI will publish a patch version (v4.38.1) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)