### PR TITLE
fix(v2): Select option label breaking into two lines during search

### DIFF
--- a/lib/v2/components/inputs/Select/Select.test.tsx
+++ b/lib/v2/components/inputs/Select/Select.test.tsx
@@ -441,6 +441,31 @@ describe('Select - Search functionality', () => {
     })
   })
 
+  it('keeps highlighted label parts in a single element separate from subLabel', async () => {
+    const optionsWithSubLabel = fruitOptions.map((option) => ({
+      ...option,
+      subLabel: `${option.label} subLabel`
+    }))
+
+    render(<Select {...createProps({ options: optionsWithSubLabel })} />)
+    openSelect()
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(SEARCH_PLACEHOLDER)
+      ).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText(SEARCH_PLACEHOLDER), {
+      target: { value: 'app' }
+    })
+
+    const option = await screen.findByTestId(`${SELECT_OPTION_PREFIX}apple`)
+    const mark = option.querySelector('mark')
+    expect(mark).toHaveTextContent('App')
+    expect(mark?.parentElement).toHaveTextContent(/^Apple$/)
+  })
+
   it('shows "No results found" when search has no matches', async () => {
     render(<Select {...createProps({ options: fruitOptions })} />)
     openSelect()

--- a/lib/v2/components/inputs/Select/Select.tsx
+++ b/lib/v2/components/inputs/Select/Select.tsx
@@ -495,12 +495,14 @@ export function Select({
               <span className={styles.menuItemIcon}>{option.icon}</span>
             ) : null}
             <span className={styles.menuItemText}>
-              {highlightText(
-                option.label,
-                searchQuery,
-                'mark',
-                styles.highlight
-              )}
+              <span className={styles.menuItemLabel}>
+                {highlightText(
+                  option.label,
+                  searchQuery,
+                  'mark',
+                  styles.highlight
+                )}
+              </span>
               {option.subLabel ? (
                 <span className={styles.menuItemSubLabel}>
                   {option.subLabel}

--- a/lib/v2/components/inputs/Select/select.module.scss
+++ b/lib/v2/components/inputs/Select/select.module.scss
@@ -358,6 +358,12 @@
   min-width: 0;
 }
 
+.menuItemLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .menuItemSubLabel {
   overflow: hidden;
   font-size: 11px;


### PR DESCRIPTION
## Problem
When searching in a `Select` dropdown, option labels render on two lines: the matched text appears as a full-width highlighted bar on the first line, and the rest of the label drops to a second line (seen in Observe's Customer Selection popup).

## Root cause
`highlightText()` splits the label into multiple React nodes (`<mark>` + text fragments). These land directly inside `.menuItemText`, which is `display: flex; flex-direction: column` (used to stack label above subLabel) — so each part becomes its own stacked flex item, and the `<mark>` stretches to full width.

## Fix
Wrap the highlighted label parts in a single `.menuItemLabel` span so the label stays one flex item, with the ellipsis treatment applied to it.

## Testing
- Added a regression test that verifies the highlighted label parts stay in a single element separate from the subLabel (fails without the fix, passes with it).
- All 34 Select tests pass; no new typecheck or lint errors in v2 Select files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)