### PR TITLE
fix(v2): Table with maxHeight grows with content instead of filling parent

### DIFF
--- a/lib/v2/components/Table/Table/Table.maxHeight.test.tsx
+++ b/lib/v2/components/Table/Table/Table.maxHeight.test.tsx
@@ -1,0 +1,70 @@
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Table } from './Table'
+
+interface Item {
+  id: number
+  name: string
+}
+
+const COLUMNS: ColumnDef<Item>[] = [
+  { id: 'id', accessorKey: 'id', header: 'ID' },
+  { id: 'name', accessorKey: 'name', header: 'Name' }
+]
+
+const DATA: Item[] = [
+  { id: 1, name: 'Item 1' },
+  { id: 2, name: 'Item 2' },
+  { id: 3, name: 'Item 3' }
+]
+
+const WRAPPER_SELECTOR = '[class*="customTableWrapper"]'
+const CAPPED_CLASS = 'cappedTable'
+const MAX_HEIGHT = 300
+const MAX_HEIGHT_STYLE = `${MAX_HEIGHT}px`
+
+const getWrapper = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>(WRAPPER_SELECTOR)
+
+describe('Table maxHeight', () => {
+  it('caps the wrapper instead of filling the parent when maxHeight is set', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        maxHeight={MAX_HEIGHT}
+      />
+    )
+    const wrapper = getWrapper(container)
+    expect(wrapper?.className).toContain(CAPPED_CLASS)
+    expect(wrapper?.style.maxHeight).toBe(MAX_HEIGHT_STYLE)
+  })
+
+  it('does not cap the wrapper when maxHeight is not set', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+      />
+    )
+    expect(getWrapper(container)?.className).not.toContain(CAPPED_CLASS)
+  })
+
+  it('keeps the full-height scroll viewport in endless mode even with maxHeight', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        endless
+        hasMore={false}
+        maxHeight={MAX_HEIGHT}
+      />
+    )
+    const wrapper = getWrapper(container)
+    expect(wrapper?.className).not.toContain(CAPPED_CLASS)
+    expect(wrapper?.style.maxHeight).toBe(MAX_HEIGHT_STYLE)
+  })
+})

--- a/lib/v2/components/Table/Table/Table.test.tsx
+++ b/lib/v2/components/Table/Table/Table.test.tsx
@@ -113,6 +113,7 @@ describe('Table', () => {
       )
       expect(screen.getByText(EMPTY_MESSAGE)).toBeInTheDocument()
     })
+
   })
 
   describe('row click handler', () => {
@@ -233,6 +234,36 @@ describe('Table', () => {
         })
       })
     })
+  })
+})
+
+describe('Table maxHeight', () => {
+  it('caps the wrapper instead of filling the parent when maxHeight is set', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        maxHeight={300}
+      />
+    )
+    const wrapper = container.querySelector<HTMLElement>(
+      '[class*="customTableWrapper"]'
+    )
+    expect(wrapper?.className).toContain('cappedTable')
+    expect(wrapper?.style.maxHeight).toBe('300px')
+  })
+
+  it('does not cap the wrapper when maxHeight is not set', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+      />
+    )
+    const wrapper = container.querySelector<HTMLElement>(
+      '[class*="customTableWrapper"]'
+    )
+    expect(wrapper?.className).not.toContain('cappedTable')
   })
 })
 

--- a/lib/v2/components/Table/Table/Table.test.tsx
+++ b/lib/v2/components/Table/Table/Table.test.tsx
@@ -237,36 +237,6 @@ describe('Table', () => {
   })
 })
 
-describe('Table maxHeight', () => {
-  it('caps the wrapper instead of filling the parent when maxHeight is set', () => {
-    const { container } = render(
-      <Table
-        columns={COLUMNS}
-        data={DATA}
-        maxHeight={300}
-      />
-    )
-    const wrapper = container.querySelector<HTMLElement>(
-      '[class*="customTableWrapper"]'
-    )
-    expect(wrapper?.className).toContain('cappedTable')
-    expect(wrapper?.style.maxHeight).toBe('300px')
-  })
-
-  it('does not cap the wrapper when maxHeight is not set', () => {
-    const { container } = render(
-      <Table
-        columns={COLUMNS}
-        data={DATA}
-      />
-    )
-    const wrapper = container.querySelector<HTMLElement>(
-      '[class*="customTableWrapper"]'
-    )
-    expect(wrapper?.className).not.toContain('cappedTable')
-  })
-})
-
 describe('Table rowActions', () => {
   const ROW_ACTIONS: RowAction<Item>[] = [
     {

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -461,7 +461,7 @@ export function Table<TData = unknown>({
       style={wrapperStyle}
       className={clsx(styles.customTableWrapper, {
         [styles.compactTable]: effectiveIsCompact,
-        [styles.cappedTable]: Boolean(maxHeight),
+        [styles.cappedTable]: Boolean(maxHeight) && !endless,
         [styles.fetching]: isFetching
       })}
     >

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -459,11 +459,11 @@ export function Table<TData = unknown>({
   return (
     <div
       style={wrapperStyle}
-      className={clsx(
-        styles.customTableWrapper,
-        effectiveIsCompact && styles.compactTable,
-        isFetching && styles.fetching
-      )}
+      className={clsx(styles.customTableWrapper, {
+        [styles.compactTable]: effectiveIsCompact,
+        [styles.cappedTable]: Boolean(maxHeight),
+        [styles.fetching]: isFetching
+      })}
     >
       <TableHeaderSection
         activeFilters={activeFilters}

--- a/lib/v2/components/Table/Table/table.module.scss
+++ b/lib/v2/components/Table/Table/table.module.scss
@@ -18,6 +18,13 @@
     transition: opacity 0.15s ease;
   }
 
+  // Grow with content up to the consumer's maxHeight instead of always
+  // filling the parent. Children keep their flex sizing so the body still
+  // scrolls internally once content exceeds the cap.
+  &.cappedTable {
+    height: auto;
+  }
+
   &.compactTable {
     height: auto;
 


### PR DESCRIPTION
## Problem
Tables render full height even when their content doesn't fill them. Any `Table` given a `maxHeight` (e.g. Observe's Filesystems/Tenants tabs with `maxHeight='calc(100vh - 280px)'`) always stretches to that cap, because:
1. `maxHeight` disables the auto-compact detection entirely, and
2. the wrapper keeps its default `height: 100%`, filling the parent up to `max-height` regardless of row count.

## Fix
`maxHeight` now means **grow with content up to the cap** instead of **always be this tall**: when `maxHeight` is set, the wrapper gets a `cappedTable` class (`height: auto`). Children keep their flex sizing, so once content exceeds the cap the body still scrolls internally, exactly as before.

Tables without `maxHeight` are unchanged (full-height with auto-compact when rows < page size).

### Scope of the capped behavior
- **Endless mode is excluded** (`Boolean(maxHeight) && !endless`): the endless sentinel observes against the scroll container, so an auto-height wrapper would keep it intersecting and chain eager loads. Matches the existing endless opt-out from compact mode.
- **Empty tables DO hug content when capped** — intentional. The empty state has an intrinsic 400px height, so the table renders header + empty message + footer instead of stretching to a large cap. With small caps the result is identical to before.
- **Paginated tables DO hug on short last pages when capped** — intentional and consistent with existing behavior: auto-compact (non-capped) already shrinks short last pages even while pagination is visible. Full pages exceed any reasonable cap and clamp exactly as before.

(The full-height exceptions listed in an earlier revision of this description — endless/pagination/empty — described the auto-compact path for tables *without* `maxHeight`, which this PR doesn't touch.)

## Verification
- Rendered the exact CSS chain in a real browser: 3-row capped table hugs content (193px vs 700px parent); 20-row capped table clamps at the 300px cap with the body scrolling internally; uncapped table still fills its parent.
- Added regression tests for the `cappedTable` class incl. the endless exclusion; all 98 Table tests pass, no new lint/typecheck errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)