### PR TITLE
fix(v2): bound capped tables by parent space to avoid double scroll

### DIFF
--- a/lib/v2/components/StatBox/statBox.module.scss
+++ b/lib/v2/components/StatBox/statBox.module.scss
@@ -209,7 +209,8 @@
 
 .skeletonMain {
   width: 60%;
-  height: 38px;
+  height: 28px;
+  margin-top: 7px;
   border-radius: 4px;
   background: var(--gray-300-700);
 

--- a/lib/v2/components/Table/Table/Table.maxHeight.test.tsx
+++ b/lib/v2/components/Table/Table/Table.maxHeight.test.tsx
@@ -22,12 +22,16 @@ const DATA: Item[] = [
 ]
 
 const WRAPPER_SELECTOR = '[class*="customTableWrapper"]'
+const CAP_BOX_SELECTOR = '[class*="tableCapBox"]'
 const CAPPED_CLASS = 'cappedTable'
 const MAX_HEIGHT = 300
 const MAX_HEIGHT_STYLE = `${MAX_HEIGHT}px`
 
 const getWrapper = (container: HTMLElement) =>
   container.querySelector<HTMLElement>(WRAPPER_SELECTOR)
+
+const getCapBox = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>(CAP_BOX_SELECTOR)
 
 describe('Table maxHeight', () => {
   it('caps the wrapper instead of filling the parent when maxHeight is set', () => {
@@ -43,6 +47,19 @@ describe('Table maxHeight', () => {
     expect(wrapper?.style.maxHeight).toBe(MAX_HEIGHT_STYLE)
   })
 
+  it('bounds a capped table by its parent via the cap box', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        data={DATA}
+        maxHeight={MAX_HEIGHT}
+      />
+    )
+    const capBox = getCapBox(container)
+    expect(capBox).toBeInTheDocument()
+    expect(capBox?.contains(getWrapper(container))).toBe(true)
+  })
+
   it('does not cap the wrapper when maxHeight is not set', () => {
     const { container } = render(
       <Table
@@ -51,6 +68,7 @@ describe('Table maxHeight', () => {
       />
     )
     expect(getWrapper(container)?.className).not.toContain(CAPPED_CLASS)
+    expect(getCapBox(container)).not.toBeInTheDocument()
   })
 
   it('keeps the full-height scroll viewport in endless mode even with maxHeight', () => {
@@ -66,5 +84,6 @@ describe('Table maxHeight', () => {
     const wrapper = getWrapper(container)
     expect(wrapper?.className).not.toContain(CAPPED_CLASS)
     expect(wrapper?.style.maxHeight).toBe(MAX_HEIGHT_STYLE)
+    expect(getCapBox(container)).not.toBeInTheDocument()
   })
 })

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -456,12 +456,14 @@ export function Table<TData = unknown>({
     setActiveFilters([])
   }
 
-  return (
+  const isCapped = Boolean(maxHeight) && !endless
+
+  const tableElement = (
     <div
       style={wrapperStyle}
       className={clsx(styles.customTableWrapper, {
         [styles.compactTable]: effectiveIsCompact,
-        [styles.cappedTable]: Boolean(maxHeight) && !endless,
+        [styles.cappedTable]: isCapped,
         [styles.fetching]: isFetching
       })}
     >
@@ -651,4 +653,10 @@ export function Table<TData = unknown>({
       })}
     </div>
   )
+
+  if (!isCapped) {
+    return tableElement
+  }
+
+  return <div className={styles.tableCapBox}>{tableElement}</div>
 }

--- a/lib/v2/components/Table/Table/table.module.scss
+++ b/lib/v2/components/Table/Table/table.module.scss
@@ -46,6 +46,14 @@
   }
 }
 
+.tableCapBox {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-height: 100%;
+  width: 100%;
+}
+
 .tableHeader {
   padding: 12px 16px;
   background-color: var(--gray-100-900);


### PR DESCRIPTION
## Problem
Follow-up to #442. A capped table (`height: auto` + `max-height: <cap>`) can overshoot its parent's actual available space when the cap overestimates it — e.g. Observe's Alerts tab passes `maxHeight='calc(100vh - 280px)'` but the content above the table takes more than 280px. The wrapper grows past the section, the section (`overflow-x: auto` forces `overflow-y: auto` too) grows a second scrollbar, and the pagination footer lands below the fold. Before #442 this was masked by `height: 100%`, which sized the wrapper to the parent regardless of the cap.

## Fix
Capped tables (`maxHeight` set, not endless) are wrapped in a minimal `tableCapBox` div carrying `max-height: 100%`:
- **Definite parent height** (the common layout): the box binds to the parent, so the table fills at most the visible space — single internal scroll, footer visible.
- **Indefinite parent height**: percentage max-height is gracefully ignored and the wrapper's own `maxHeight` still caps growth (unchanged from #442).

A single element can't carry both bounds: `max-height: min(<cap>, 100%)` loses the cap entirely when the percentage can't resolve (verified in-browser — the whole `min()` is dropped for indefinite parents).

Uncapped and endless tables render without the box — DOM unchanged.

## Verification
In a real browser, with a replica of the exact CSS chain and of Observe's Alerts tab layout (stretched flex section with `overflow-x: auto`, 30 rows, oversized cap):
- wrapper clamps to the section's available height (480px vs the ~800px cap), no outer scrollbar, body scrolls internally, footer visible
- indefinite parent: cap still honored (300px), inner scroll works
- short content still hugs (193px in a 500px parent)

All 99 Table tests pass (added cap-box assertions); no new lint/typecheck errors.

## Consumer note (Observe)
Several Observe tabs carry `!important` overrides on `:global(.customTableWrapper)` (alertsTab/eventsTab/filesystemsContent/tenantsTab/s3BucketsContent `.module.scss`) that replicate the old workaround. They should be removed when bumping to the release containing this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)