### PR TITLE
fix(v2): shrink table height to fit a partial last page

### DIFF
--- a/lib/v2/components/Table/Table/Table.compact.test.tsx
+++ b/lib/v2/components/Table/Table/Table.compact.test.tsx
@@ -1,0 +1,60 @@
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Table } from './Table'
+
+interface Item {
+  id: number
+  name: string
+}
+
+const COLUMNS: ColumnDef<Item>[] = [
+  { id: 'id', accessorKey: 'id', header: 'ID' },
+  { id: 'name', accessorKey: 'name', header: 'Name' }
+]
+
+const WRAPPER_SELECTOR = '[class*="customTableWrapper"]'
+const COMPACT_CLASS = 'compactTable'
+const PAGE_SIZE = 50
+const TOTAL_ITEMS = 55
+
+const makeRows = (count: number): Item[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    name: `Item ${index + 1}`
+  }))
+
+const getWrapper = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>(WRAPPER_SELECTOR)
+
+describe('Table compact height', () => {
+  it('shrinks to fit a partial last page in manual pagination', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        currentPage={2}
+        data={makeRows(TOTAL_ITEMS - PAGE_SIZE)}
+        fixedPageSize={PAGE_SIZE}
+        itemsAmount={TOTAL_ITEMS}
+        manualPagination
+      />
+    )
+    expect(getWrapper(container)?.className).toContain(COMPACT_CLASS)
+  })
+
+  it('keeps full height on a full page in manual pagination', () => {
+    const { container } = render(
+      <Table
+        columns={COLUMNS}
+        currentPage={1}
+        data={makeRows(PAGE_SIZE)}
+        fixedPageSize={PAGE_SIZE}
+        itemsAmount={TOTAL_ITEMS}
+        manualPagination
+      />
+    )
+    expect(getWrapper(container)?.className).not.toContain(COMPACT_CLASS)
+  })
+})

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -39,9 +39,7 @@ import { TableHeaderSection } from './TableHeaderSection'
 import styles from './table.module.scss'
 
 const DEFAULT_PAGE_SIZE = 25
-const MAX_ROWS_FOR_COMPACT = 10
 const FIRST_PAGE = 1
-const COMPACT_HALF_DIVISOR = 2
 const ROW_ACTIONS_COLUMN_SIZE = 56
 
 const EMPTY_ACTIVE_FILTERS: ActiveFilter[] = []
@@ -368,25 +366,8 @@ export function Table<TData = unknown>({
       return false
     }
 
-    if (manualPagination) {
-      const halfPageSizeThreshold = effectivePageSize / COMPACT_HALF_DIVISOR
-      return (
-        visibleRowCount <
-          Math.min(MAX_ROWS_FOR_COMPACT, halfPageSizeThreshold) &&
-        !showPagination
-      )
-    }
-
     return visibleRowCount < effectivePageSize
-  }, [
-    visibleRowCount,
-    maxHeight,
-    manualPagination,
-    loading,
-    drawerOpen,
-    effectivePageSize,
-    showPagination
-  ])
+  }, [visibleRowCount, maxHeight, loading, drawerOpen, effectivePageSize])
 
   const { displayRows, effectiveIsCompact, effectiveShowPagination } =
     useEndlessScroll({


### PR DESCRIPTION
## What

A manually-paginated `Table` reserved full page-size height on **every** page, so the last page (e.g. 5 of 55 rows) rendered its rows with a large empty gap below and the pagination controls pinned to the bottom.

## Change

`isCompactTable` now uses the same rule for manual pagination that the non-manual path already used — `visibleRowCount < effectivePageSize`. A partial page (the last page) shrinks to fit its rows; full pages keep their height, so mid-list paging doesn't jump. Removes the now-unused `MAX_ROWS_FOR_COMPACT` / `COMPACT_HALF_DIVISOR` constants and the `!showPagination` gate that was blocking this.

## UX note

On the last page the table now fits its rows, so the pagination controls move up on that page (intended).

## Testing

- New `Table.compact.test.tsx`: partial last page → compact; full page → not compact.
- Full Table suite passes (123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)