### PR TITLE
fix(v2): toastSuccess forwards toastId to sonner (legacy-compat signa…

### DIFF
--- a/lib/v2/utils/toast.test.ts
+++ b/lib/v2/utils/toast.test.ts
@@ -27,7 +27,14 @@ describe('toast helpers', () => {
 
   it('toastSuccess delegates to toast.success', () => {
     toastSuccess('Saved')
-    expect(toastMock.success).toHaveBeenCalledWith('Saved')
+    expect(toastMock.success).toHaveBeenCalledWith('Saved', { id: undefined })
+  })
+
+  it('toastSuccess forwards the toastId as the sonner id', () => {
+    toastSuccess('Saved', undefined, 'save-toast')
+    expect(toastMock.success).toHaveBeenCalledWith('Saved', {
+      id: 'save-toast'
+    })
   })
 
   it('toastInfo delegates to toast.info', () => {

--- a/lib/v2/utils/toast.ts
+++ b/lib/v2/utils/toast.ts
@@ -2,8 +2,17 @@ import { toast } from 'sonner'
 
 const DEFAULT_ERROR_MESSAGE = 'An error occurred'
 
-export const toastSuccess = (message: string) => {
-  toast.success(message)
+/**
+ * Signature mirrors the legacy `Utils.toastSuccess` (hence the unused `_type`)
+ * so existing call sites migrate unchanged; `toastId` keeps its dedupe role as
+ * the sonner toast id.
+ */
+export const toastSuccess = (
+  message: string,
+  _type?: unknown,
+  toastId?: string
+) => {
+  toast.success(message, { id: toastId })
 }
 
 const getDataPayloadMessage = (data: unknown): string | null => {


### PR DESCRIPTION
…ture)