### PR TITLE
feat(v2): StatBox main-value adornment and 24h chart tooltip timestamps (WH-4206)

### DIFF
--- a/lib/v2/components/MenuPopover/MenuPopover.tsx
+++ b/lib/v2/components/MenuPopover/MenuPopover.tsx
@@ -32,7 +32,8 @@ export function MenuPopover({
 
   useClickOutside(popRef as unknown as RefObject<HTMLElement>, onClose, {
     additionalRefs: [anchorRef],
-    enabled: open
+    enabled: open,
+    capture: true
   })
 
   const { position } = usePopoverPosition(open, anchorRef, onClose, {

--- a/lib/v2/components/StatBox/StatBox.test.tsx
+++ b/lib/v2/components/StatBox/StatBox.test.tsx
@@ -43,6 +43,20 @@ describe('StatBox', () => {
       expect(screen.getByText('132.0')).toBeInTheDocument()
     })
 
+    it('renders the main value adornment next to the main value', () => {
+      render(
+        <StatBox
+          colorVariant='purple'
+          mainValue={11}
+          mainValueAdornment={<button type='button'>7 Stale</button>}
+          title='Clusters'
+        />
+      )
+      expect(
+        screen.getByRole('button', { name: '7 Stale' })
+      ).toBeInTheDocument()
+    })
+
     it('renders no sub-stats when the list is empty', () => {
       render(
         <StatBox
@@ -66,7 +80,9 @@ describe('StatBox', () => {
           title='Throughput'
         />
       )
-      expect(screen.getByTestId('stat-box-skeleton-loading')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('stat-box-skeleton-loading')
+      ).toBeInTheDocument()
       expect(screen.queryByText('146.8')).not.toBeInTheDocument()
     })
 

--- a/lib/v2/components/StatBox/StatBox.tsx
+++ b/lib/v2/components/StatBox/StatBox.tsx
@@ -11,6 +11,7 @@ export function StatBox({
   colorVariant,
   mainValue,
   mainUnit,
+  mainValueAdornment,
   subStats,
   status = STAT_BOX_STATUS.READY,
   dataTestId
@@ -20,10 +21,17 @@ export function StatBox({
 
   const content = (
     <>
-      {mainUnit ? (
+      {mainUnit || mainValueAdornment ? (
         <div className={styles.mainValueGroup}>
           <span className={styles.mainValue}>{mainValue}</span>
-          <span className={styles.mainUnit}>{mainUnit}</span>
+          {mainUnit ? (
+            <span className={styles.mainUnit}>{mainUnit}</span>
+          ) : null}
+          {mainValueAdornment ? (
+            <span className={styles.mainValueAdornment}>
+              {mainValueAdornment}
+            </span>
+          ) : null}
         </div>
       ) : (
         <span className={styles.mainValue}>{mainValue}</span>

--- a/lib/v2/components/StatBox/statBox.module.scss
+++ b/lib/v2/components/StatBox/statBox.module.scss
@@ -73,6 +73,13 @@
   font-size: 14px;
 }
 
+.mainValueAdornment {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  margin-left: 4px;
+}
+
 .subStats {
   display: flex;
   flex-direction: row;
@@ -151,6 +158,7 @@
 .statContent.purple {
   .subStat {
     flex-direction: row-reverse;
+    justify-content: flex-end;
     gap: 4px;
     font-size: 14px;
   }

--- a/lib/v2/components/StatBox/statBoxConstants.ts
+++ b/lib/v2/components/StatBox/statBoxConstants.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 export const STAT_COLOR_VARIANT = {
   PURPLE: 'purple',
   FUCHSIA: 'fuchsia',
@@ -29,6 +31,7 @@ export interface StatBoxProps {
   colorVariant: StatColorVariant
   mainValue: string | number
   mainUnit?: string
+  mainValueAdornment?: ReactNode
   subStats?: StatBoxSubStat[]
   status?: StatBoxStatus
   dataTestId?: string

--- a/lib/v2/components/charts/CustomTooltip/CustomTooltip.test.tsx
+++ b/lib/v2/components/charts/CustomTooltip/CustomTooltip.test.tsx
@@ -58,7 +58,7 @@ describe('CustomTooltip', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders a formatted timestamp header when the payload carries a timestamp', () => {
+  it('renders a timestamp header with date and 24-hour time matching the axis format', () => {
     render(
       <CustomTooltip
         active
@@ -71,9 +71,11 @@ describe('CustomTooltip', () => {
       />
     )
 
-    expect(screen.getByTestId(TOOLTIP_TEST_ID).textContent).toMatch(
-      /\d{2}\/\d{2}\/\d{4}/
-    )
+    const tooltipText = screen.getByTestId(TOOLTIP_TEST_ID).textContent
+    expect(tooltipText).toMatch(/(\d{2}\s\w{3}|\w{3}\s\d{2})/)
+    expect(tooltipText).toMatch(/\d{2}:\d{2}/)
+    expect(tooltipText).not.toMatch(/am|pm/i)
+    expect(tooltipText).not.toMatch(/\d{2}\/\d{2}\/\d{4}/)
   })
 
   it('renders series names, dot colors and values', () => {

--- a/lib/v2/components/charts/CustomTooltip/CustomTooltip.tsx
+++ b/lib/v2/components/charts/CustomTooltip/CustomTooltip.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx'
 
 import { EMPTY_STRING } from '#v2/utils/consts'
-import { formatTimestamp } from '#v2/utils/timeUtils'
 
 import { DateTimeIcon } from '../../../icons'
 import { type SeriesConfig, type TooltipPayloadItem } from '../chartTypes'
+import { formatTooltipTimestamp } from '../utils/xAxisFormatters'
 
 import styles from './customTooltip.module.scss'
 
@@ -48,12 +48,12 @@ export function CustomTooltip({
       }
 
       if (payload[0]?.payload?.timestamp) {
-        return formatTimestamp(payload[0].payload.timestamp)
+        return formatTooltipTimestamp(payload[0].payload.timestamp)
       }
 
       const numLabel = Number(timeLabel)
       if (!Number.isNaN(numLabel) && numLabel > MIN_TIMESTAMP_MS) {
-        return formatTimestamp(numLabel)
+        return formatTooltipTimestamp(numLabel)
       }
 
       return timeLabel

--- a/lib/v2/components/charts/utils/xAxisFormatters.test.ts
+++ b/lib/v2/components/charts/utils/xAxisFormatters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   DEFAULT_CHART_MARGIN,
+  formatTooltipTimestamp,
   formatXAxisTimestamp,
   getBottomMargin,
   getChartMargin,
@@ -10,6 +11,7 @@ import {
 } from './xAxisFormatters'
 
 const CUSTOM_ISO_RANGE = '2025-12-09T23:30:00+02:00:2025-12-10T07:15:00+02:00'
+const SAMPLE_DATE_ISO = '2024-03-15T14:30:00Z'
 
 const LONG_RANGE_BOTTOM_MARGIN = 20
 const DEFAULT_BOTTOM_MARGIN = 5
@@ -46,7 +48,7 @@ describe('xAxisFormatters', () => {
   })
 
   describe('getRangeDomain', () => {
-    const NOW = new Date('2024-03-15T14:30:00Z').getTime()
+    const NOW = new Date(SAMPLE_DATE_ISO).getTime()
     const MS_PER_HOUR = 3_600_000
     const HOURS_PER_DAY = 24
     const MS_PER_DAY = HOURS_PER_DAY * MS_PER_HOUR
@@ -86,7 +88,7 @@ describe('xAxisFormatters', () => {
   })
 
   describe('formatXAxisTimestamp', () => {
-    const timestamp = new Date('2024-03-15T14:30:00Z').getTime()
+    const timestamp = new Date(SAMPLE_DATE_ISO).getTime()
 
     it('returns time only for short range (1d)', () => {
       const result = formatXAxisTimestamp(timestamp, '1d')
@@ -118,6 +120,29 @@ describe('xAxisFormatters', () => {
       const result = formatXAxisTimestamp(timestamp, CUSTOM_ISO_RANGE)
 
       expect(result).toContain('\n')
+    })
+  })
+
+  describe('formatTooltipTimestamp', () => {
+    const timestamp = new Date(SAMPLE_DATE_ISO).getTime()
+
+    it('formats a millisecond timestamp as date and 24-hour time', () => {
+      const result = formatTooltipTimestamp(timestamp)
+
+      expect(result).toMatch(/(\d{2}\s\w{3}|\w{3}\s\d{2})/)
+      expect(result).toContain('2024')
+      expect(result).toMatch(/\d{2}:\d{2}$/)
+      expect(result).not.toMatch(/am|pm/i)
+    })
+
+    it('accepts a numeric string timestamp', () => {
+      expect(formatTooltipTimestamp(String(timestamp))).toBe(
+        formatTooltipTimestamp(timestamp)
+      )
+    })
+
+    it('returns the input unchanged when it cannot be parsed', () => {
+      expect(formatTooltipTimestamp('not-a-date')).toBe('not-a-date')
     })
   })
 

--- a/lib/v2/components/charts/utils/xAxisFormatters.ts
+++ b/lib/v2/components/charts/utils/xAxisFormatters.ts
@@ -1,7 +1,8 @@
+import { EMPTY_STRING } from '#v2/utils/consts'
 import { getUserLocale } from '#v2/utils/timeUtils'
 
 /**
- * Utility functions for consistent X-axis formatting across all charts
+ * Utility functions for consistent time formatting across all charts
  */
 
 const SECONDS_IN_MINUTE = 60
@@ -85,6 +86,39 @@ export function formatXAxisTimestamp(timestamp: number, range: string): string {
     minute: '2-digit',
     hour12: false
   })
+}
+
+/**
+ * Formats a timestamp for the chart tooltip header, e.g. "08 Jul 2026, 22:36".
+ * Uses the same locale-aware date style and 24-hour clock as the X-axis ticks;
+ * the date is always included because short-range axes show time only.
+ *
+ * @param timestamp - Unix timestamp in milliseconds, or a parseable date string
+ */
+export function formatTooltipTimestamp(timestamp: number | string): string {
+  const numericTimestamp =
+    typeof timestamp === 'string' && timestamp.trim() !== EMPTY_STRING
+      ? Number(timestamp)
+      : timestamp
+  const date = new Date(
+    Number.isNaN(numericTimestamp) ? timestamp : numericTimestamp
+  )
+  if (Number.isNaN(date.getTime())) {
+    return String(timestamp)
+  }
+
+  const locale = getUserLocale()
+  const dateStr = date.toLocaleDateString(locale, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  })
+  const timeStr = date.toLocaleTimeString(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  })
+  return `${dateStr}, ${timeStr}`
 }
 
 /** Bottom margin for charts with two-line dates */

--- a/lib/v2/components/index.ts
+++ b/lib/v2/components/index.ts
@@ -108,6 +108,7 @@ export { calculateChartDomain } from './charts/utils/chartDomainUtils'
 export { syncByNearestTimestamp } from './charts/utils/chartSyncUtils'
 export {
   DEFAULT_CHART_MARGIN,
+  formatTooltipTimestamp,
   formatXAxisTimestamp,
   getBottomMargin,
   getChartMargin,

--- a/lib/v2/hooks/useClickOutside.test.ts
+++ b/lib/v2/hooks/useClickOutside.test.ts
@@ -28,7 +28,8 @@ describe('useClickOutside', () => {
 
     expect(document.addEventListener).toHaveBeenCalledWith(
       'mousedown',
-      expect.any(Function)
+      expect.any(Function),
+      false
     )
   })
 
@@ -40,7 +41,19 @@ describe('useClickOutside', () => {
 
     expect(document.removeEventListener).toHaveBeenCalledWith(
       'mousedown',
-      expect.any(Function)
+      expect.any(Function),
+      false
+    )
+  })
+
+  it('listens in the capture phase when capture is true', () => {
+    const handler = vi.fn()
+    renderHook(() => useClickOutside(ref, handler, { capture: true }))
+
+    expect(document.addEventListener).toHaveBeenCalledWith(
+      'mousedown',
+      expect.any(Function),
+      true
     )
   })
 

--- a/lib/v2/hooks/useClickOutside.ts
+++ b/lib/v2/hooks/useClickOutside.ts
@@ -13,6 +13,7 @@ interface UseClickOutsideOptions {
   additionalSelectors?: string[]
   additionalDataAttributes?: string[]
   enabled?: boolean
+  capture?: boolean
 }
 
 /**
@@ -95,7 +96,8 @@ export const useClickOutside = (
     additionalRefs = EMPTY_REF_ARRAY,
     additionalSelectors = EMPTY_STRING_ARRAY,
     additionalDataAttributes = EMPTY_STRING_ARRAY,
-    enabled = true
+    enabled = true,
+    capture = false
   } = options
 
   useEffect(() => {
@@ -129,10 +131,14 @@ export const useClickOutside = (
       handler()
     }
 
-    document.addEventListener(DOM_EVENTS.MOUSEDOWN, handleClickOutside)
+    document.addEventListener(DOM_EVENTS.MOUSEDOWN, handleClickOutside, capture)
 
     return () => {
-      document.removeEventListener(DOM_EVENTS.MOUSEDOWN, handleClickOutside)
+      document.removeEventListener(
+        DOM_EVENTS.MOUSEDOWN,
+        handleClickOutside,
+        capture
+      )
     }
   }, [
     ref,
@@ -140,6 +146,7 @@ export const useClickOutside = (
     additionalRefs,
     additionalSelectors,
     additionalDataAttributes,
-    enabled
+    enabled,
+    capture
   ])
 }


### PR DESCRIPTION
## What

### StatBox
- New optional `mainValueAdornment?: ReactNode` prop, rendered inside the main-value row and vertically centered against the value. Observe uses it for the stale-clusters badge on the Clusters KPI — the adornment now lives in the card's real layout and follows its container queries, replacing Observe's absolutely-positioned "phantom" overlay that drifted out of alignment on narrow screens.
- Purple sub-stats: added `justify-content: flex-end` to the reversed row so values left-align in the narrow (≤1250px container) 50%-box layout, matching the peach variant. Previously short items ("1 OCI") drifted to the right edge.

### Charts — [WH-4206](https://wekaio.atlassian.net/browse/WH-4206)
- `CustomTooltip` no longer uses the app-wide `formatTimestamp` (12-hour + `MM/DD/YYYY`), which contradicted the X-axis ticks (24-hour). New chart-scoped `formatTooltipTimestamp` — locale-aware date in the axis's style plus year, 24-hour clock, e.g. `08 Jul 2026, 22:36` — co-located with `formatXAxisTimestamp` so the two conventions stay in sync, and exported from the `/v2` index.
- The app-wide `formatTimestamp` (tables/widgets) is intentionally unchanged.

### useClickOutside / MenuPopover
- `useClickOutside` gains an opt-in `capture` flag so the outside-click listener can run in the capture phase; `MenuPopover` enables it, so the popover closes even when the clicked element stops `mousedown` propagation.

## Testing
- New unit tests: StatBox adornment rendering, `formatTooltipTimestamp` (ms timestamp, numeric string, unparseable input), updated `CustomTooltip` header assertions (24h, no AM/PM, no `MM/DD/YYYY`), and `useClickOutside` capture behavior.
- `vitest run lib/v2/components/charts` — 167 passed; StatBox suite — 15 passed; useClickOutside + MenuPopover — 14 passed.
- ESLint/Prettier/Stylelint clean on changed files.
- Verified end-to-end in Observe via `portal:` link (stale badge alignment across container-query breakpoints + tooltip format on performance charts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WH-4206]: https://wekaio.atlassian.net/browse/WH-4206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ