### PR TITLE
feat(v2): add JsonEditor component (CodeMirror 6) (WH-4209)

### DIFF
--- a/lib/v2/components/JsonEditor/JsonEditor.stories.tsx
+++ b/lib/v2/components/JsonEditor/JsonEditor.stories.tsx
@@ -1,0 +1,107 @@
+import type { JsonEditorCompletionSource, JsonEditorDecoration } from './types'
+import type { Meta, StoryObj } from '@storybook/react'
+import type { CSSProperties } from 'react'
+
+import { useState } from 'react'
+
+import { JsonEditor } from './JsonEditor'
+
+const CONTAINER_STYLE: CSSProperties = {
+  width: '560px',
+  height: '320px',
+  display: 'flex',
+  border: '1px solid var(--gray-200-800)',
+  color: 'var(--text-primary)'
+}
+
+const SAMPLE = `{
+  "id": "{{id}}",
+  "severity": "{{severity}}",
+  "cluster": "{{cluster}}",
+  "message": "{{unknown_field}}"
+}`
+
+const FIELDS = [
+  { key: 'id', detail: 'Unique notification ID' },
+  { key: 'severity', detail: 'Alert/Event severity' },
+  { key: 'cluster', detail: 'Cluster display name' },
+  { key: 'timestamp', detail: 'Trigger time (ISO 8601)' }
+]
+
+const KNOWN_KEYS = new Set(FIELDS.map((field) => field.key))
+
+const TEMPLATE_TOKEN = /\{\{\w+\}\}/g
+const BRACE_LENGTH = 2
+
+const decorations: JsonEditorDecoration[] = [
+  {
+    pattern: TEMPLATE_TOKEN,
+    className: (match) =>
+      KNOWN_KEYS.has(match.slice(BRACE_LENGTH, -BRACE_LENGTH))
+        ? 'sb-template-known'
+        : 'sb-template-unknown'
+  }
+]
+
+const completionSource: JsonEditorCompletionSource = ({ textBefore }) => {
+  const prefix = /\{\{\w*$/.exec(textBefore)
+  if (!prefix) {
+    return null
+  }
+  return {
+    from: textBefore.length - prefix[0].length,
+    options: FIELDS.map((field) => ({
+      label: `{{${field.key}}}`,
+      detail: field.detail
+    }))
+  }
+}
+
+function EditableDemo() {
+  const [value, setValue] = useState(SAMPLE)
+  return (
+    <div style={CONTAINER_STYLE}>
+      <style>
+        {`
+        .sb-template-known { color: var(--purple-700-300); font-weight: 600; }
+        .sb-template-unknown { color: var(--red-500); text-decoration: underline wavy; }
+      `}
+      </style>
+      <JsonEditor
+        completionSource={completionSource}
+        decorations={decorations}
+        onChange={setValue}
+        value={value}
+      />
+    </div>
+  )
+}
+
+const READ_ONLY_VALUE = JSON.stringify(
+  { status: 'OK', nodes: 12, healthy: true },
+  null,
+  2
+)
+
+const meta: Meta<typeof EditableDemo> = {
+  title: 'v2/JsonEditor',
+  component: EditableDemo,
+  parameters: { layout: 'centered' }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Editable: Story = {}
+
+export const ReadOnly: Story = {
+  render: () => (
+    <div style={CONTAINER_STYLE}>
+      <JsonEditor
+        maxHeight={280}
+        readOnly
+        value={READ_ONLY_VALUE}
+      />
+    </div>
+  )
+}

--- a/lib/v2/components/JsonEditor/JsonEditor.test.tsx
+++ b/lib/v2/components/JsonEditor/JsonEditor.test.tsx
@@ -1,0 +1,118 @@
+import { createRef } from 'react'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { EMPTY_STRING } from '#consts'
+
+import { JsonEditor } from './JsonEditor'
+import { type JsonEditorHandle } from './types'
+
+const SEVERITY_TOKEN = '{{severity}}'
+const SAMPLE_JSON = `{\n  "severity": "${SEVERITY_TOKEN}"\n}`
+const TOKEN_CLASS = 'template-token'
+const CONTENT_SELECTOR = '.cm-content'
+
+afterEach(cleanup)
+
+function getContentText(container: HTMLElement): string {
+  return container.querySelector(CONTENT_SELECTOR)?.textContent ?? EMPTY_STRING
+}
+
+describe('JsonEditor - rendering', () => {
+  it('renders the value in the editor', () => {
+    const { container } = render(
+      <JsonEditor
+        onChange={vi.fn()}
+        value={SAMPLE_JSON}
+      />
+    )
+    expect(getContentText(container)).toContain('"severity"')
+  })
+
+  it('renders a CodeMirror editor with the test id', () => {
+    const { getByTestId } = render(
+      <JsonEditor
+        dataTestId='json-editor'
+        onChange={vi.fn()}
+        value='{}'
+      />
+    )
+    expect(getByTestId('json-editor').querySelector('.cm-editor')).toBeTruthy()
+  })
+
+  it('makes content non-editable when readOnly', () => {
+    const { container } = render(
+      <JsonEditor
+        readOnly
+        value={SAMPLE_JSON}
+      />
+    )
+    expect(
+      container.querySelector(CONTENT_SELECTOR)?.getAttribute('contenteditable')
+    ).toBe('false')
+  })
+})
+
+describe('JsonEditor - value sync', () => {
+  it('reflects an updated value prop', () => {
+    const { container, rerender } = render(
+      <JsonEditor
+        onChange={vi.fn()}
+        value='{}'
+      />
+    )
+    rerender(
+      <JsonEditor
+        onChange={vi.fn()}
+        value='{"a":1}'
+      />
+    )
+    expect(getContentText(container)).toContain('"a"')
+  })
+})
+
+describe('JsonEditor - decorations', () => {
+  it('applies the caller className to matched text', () => {
+    const { container } = render(
+      <JsonEditor
+        decorations={[{ pattern: /\{\{\w+\}\}/g, className: TOKEN_CLASS }]}
+        onChange={vi.fn()}
+        value={SAMPLE_JSON}
+      />
+    )
+    expect(container.querySelector(`.${TOKEN_CLASS}`)?.textContent).toBe(
+      SEVERITY_TOKEN
+    )
+  })
+})
+
+describe('JsonEditor - imperative handle', () => {
+  it('inserts text and reports it through onChange', () => {
+    const onChange = vi.fn()
+    const ref = createRef<JsonEditorHandle>()
+    render(
+      <JsonEditor
+        ref={ref}
+        onChange={onChange}
+        value={EMPTY_STRING}
+      />
+    )
+    ref.current?.insert(SEVERITY_TOKEN)
+    expect(onChange).toHaveBeenCalledWith(SEVERITY_TOKEN)
+  })
+
+  it('positions the caret inside the inserted text via cursorOffsetFromEnd', () => {
+    const onChange = vi.fn()
+    const ref = createRef<JsonEditorHandle>()
+    render(
+      <JsonEditor
+        ref={ref}
+        onChange={onChange}
+        value={EMPTY_STRING}
+      />
+    )
+    ref.current?.insert('""', { cursorOffsetFromEnd: 1 })
+    ref.current?.insert('X')
+    expect(onChange).toHaveBeenLastCalledWith('"X"')
+  })
+})

--- a/lib/v2/components/JsonEditor/JsonEditor.test.tsx
+++ b/lib/v2/components/JsonEditor/JsonEditor.test.tsx
@@ -69,6 +69,23 @@ describe('JsonEditor - value sync', () => {
     )
     expect(getContentText(container)).toContain('"a"')
   })
+
+  it('does not fire onChange when the value prop is synced in', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <JsonEditor
+        onChange={onChange}
+        value='{}'
+      />
+    )
+    rerender(
+      <JsonEditor
+        onChange={onChange}
+        value='{"a":1}'
+      />
+    )
+    expect(onChange).not.toHaveBeenCalled()
+  })
 })
 
 describe('JsonEditor - decorations', () => {
@@ -83,6 +100,28 @@ describe('JsonEditor - decorations', () => {
     expect(container.querySelector(`.${TOKEN_CLASS}`)?.textContent).toBe(
       SEVERITY_TOKEN
     )
+  })
+})
+
+describe('JsonEditor - reactive layout props', () => {
+  it('toggles the line-number gutter when showLineNumbers changes', () => {
+    const { container, rerender } = render(
+      <JsonEditor
+        onChange={vi.fn()}
+        showLineNumbers
+        value='{}'
+      />
+    )
+    expect(container.querySelector('.cm-lineNumbers')).toBeTruthy()
+
+    rerender(
+      <JsonEditor
+        onChange={vi.fn()}
+        showLineNumbers={false}
+        value='{}'
+      />
+    )
+    expect(container.querySelector('.cm-lineNumbers')).toBeFalsy()
   })
 })
 

--- a/lib/v2/components/JsonEditor/JsonEditor.tsx
+++ b/lib/v2/components/JsonEditor/JsonEditor.tsx
@@ -7,21 +7,33 @@ import type {
 
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import { startCompletion } from '@codemirror/autocomplete'
-import { EditorState, type Extension } from '@codemirror/state'
-import { Compartment } from '@codemirror/state'
 import {
-  EditorView,
-  placeholder as placeholderExtension
-} from '@codemirror/view'
+  Annotation,
+  Compartment,
+  EditorState,
+  type Extension,
+  Transaction
+} from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
 import clsx from 'clsx'
 
 import { EMPTY_ARRAY, EMPTY_STRING } from '#v2/utils/consts'
 
-import { buildBaseExtensions, decorationsPlugin } from './jsonEditorSetup'
+import {
+  buildLayoutExtensions,
+  buildStaticExtensions,
+  decorationsPlugin
+} from './jsonEditorSetup'
 
 import styles from './jsonEditor.module.scss'
 
 const DEFAULT_FONT_SIZE_PX = 14
+
+/**
+ * Marks the document change made when the controlled `value` prop is synced in,
+ * so the change listener can skip it and only report genuine user edits.
+ */
+const VALUE_SYNC = Annotation.define<boolean>()
 
 export interface JsonEditorProps {
   value: string
@@ -38,13 +50,6 @@ export interface JsonEditorProps {
   autoFocus?: boolean
   extraClass?: string
   dataTestId?: string
-}
-
-function toCssSize(size: number | string | undefined): string | undefined {
-  if (size === undefined) {
-    return undefined
-  }
-  return typeof size === 'number' ? `${size}px` : size
 }
 
 /** Read-only viewers block edits and drop `contenteditable` while staying selectable. */
@@ -86,33 +91,41 @@ export const JsonEditor = forwardRef<
 
   const readOnlyCompartment = useRef(new Compartment())
   const decorationsCompartment = useRef(new Compartment())
+  const layoutCompartment = useRef(new Compartment())
 
   useEffect(() => {
     const parent = parentRef.current
     if (!parent) {
       return undefined
     }
-    const baseExtensions = buildBaseExtensions({
-      showLineNumbers,
-      fontSizePx: fontSize,
+    const staticExtensions = buildStaticExtensions({
       getCompletionSource: () => completionSourceRef.current,
       getCursorHandler: () => cursorHandlerRef.current
     })
     const extensions: Extension[] = [
-      ...baseExtensions,
-      ...(placeholder ? [placeholderExtension(placeholder)] : []),
-      EditorView.theme({
-        '.cm-scroller': {
-          minHeight: toCssSize(minHeight) ?? EMPTY_STRING,
-          maxHeight: toCssSize(maxHeight) ?? EMPTY_STRING
-        }
-      }),
+      ...staticExtensions,
+      layoutCompartment.current.of(
+        buildLayoutExtensions({
+          fontSizePx: fontSize,
+          showLineNumbers,
+          placeholder,
+          minHeight,
+          maxHeight
+        })
+      ),
       readOnlyCompartment.current.of(readOnlyExtension(readOnly)),
       decorationsCompartment.current.of(decorationsPlugin(decorations)),
       EditorView.updateListener.of((update) => {
-        if (update.docChanged) {
-          onChangeRef.current?.(update.state.doc.toString())
+        if (!update.docChanged) {
+          return
         }
+        const isValueSync = update.transactions.some((transaction) =>
+          transaction.annotation(VALUE_SYNC)
+        )
+        if (isValueSync) {
+          return
+        }
+        onChangeRef.current?.(update.state.doc.toString())
       })
     ]
     const view = new EditorView({
@@ -148,6 +161,20 @@ export const JsonEditor = forwardRef<
   }, [decorations])
 
   useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: layoutCompartment.current.reconfigure(
+        buildLayoutExtensions({
+          fontSizePx: fontSize,
+          showLineNumbers,
+          placeholder,
+          minHeight,
+          maxHeight
+        })
+      )
+    })
+  }, [fontSize, showLineNumbers, placeholder, minHeight, maxHeight])
+
+  useEffect(() => {
     const view = viewRef.current
     if (!view) {
       return
@@ -155,7 +182,8 @@ export const JsonEditor = forwardRef<
     const current = view.state.doc.toString()
     if (current !== value) {
       view.dispatch({
-        changes: { from: 0, to: current.length, insert: value }
+        changes: { from: 0, to: current.length, insert: value },
+        annotations: [VALUE_SYNC.of(true), Transaction.addToHistory.of(false)]
       })
     }
   }, [value])

--- a/lib/v2/components/JsonEditor/JsonEditor.tsx
+++ b/lib/v2/components/JsonEditor/JsonEditor.tsx
@@ -1,0 +1,197 @@
+import type {
+  JsonEditorCompletionSource,
+  JsonEditorCursorContext,
+  JsonEditorDecoration,
+  JsonEditorHandle
+} from './types'
+
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+import { startCompletion } from '@codemirror/autocomplete'
+import { EditorState, type Extension } from '@codemirror/state'
+import { Compartment } from '@codemirror/state'
+import {
+  EditorView,
+  placeholder as placeholderExtension
+} from '@codemirror/view'
+import clsx from 'clsx'
+
+import { EMPTY_ARRAY, EMPTY_STRING } from '#v2/utils/consts'
+
+import { buildBaseExtensions, decorationsPlugin } from './jsonEditorSetup'
+
+import styles from './jsonEditor.module.scss'
+
+const DEFAULT_FONT_SIZE_PX = 14
+
+export interface JsonEditorProps {
+  value: string
+  onChange?: (value: string) => void
+  readOnly?: boolean
+  placeholder?: string
+  minHeight?: number | string
+  maxHeight?: number | string
+  fontSize?: number
+  showLineNumbers?: boolean
+  completionSource?: JsonEditorCompletionSource
+  decorations?: JsonEditorDecoration[]
+  onCursorActivity?: (context: JsonEditorCursorContext) => void
+  autoFocus?: boolean
+  extraClass?: string
+  dataTestId?: string
+}
+
+function toCssSize(size: number | string | undefined): string | undefined {
+  if (size === undefined) {
+    return undefined
+  }
+  return typeof size === 'number' ? `${size}px` : size
+}
+
+/** Read-only viewers block edits and drop `contenteditable` while staying selectable. */
+function readOnlyExtension(readOnly: boolean): Extension {
+  return [EditorState.readOnly.of(readOnly), EditorView.editable.of(!readOnly)]
+}
+
+export const JsonEditor = forwardRef<
+  JsonEditorHandle,
+  Readonly<JsonEditorProps>
+>(function JsonEditor(
+  {
+    value,
+    onChange,
+    readOnly = false,
+    placeholder = EMPTY_STRING,
+    minHeight,
+    maxHeight,
+    fontSize = DEFAULT_FONT_SIZE_PX,
+    showLineNumbers = true,
+    completionSource,
+    decorations = EMPTY_ARRAY as JsonEditorDecoration[],
+    onCursorActivity,
+    autoFocus = false,
+    extraClass = EMPTY_STRING,
+    dataTestId
+  },
+  ref
+) {
+  const parentRef = useRef<HTMLDivElement>(null)
+  const viewRef = useRef<EditorView | null>(null)
+
+  const onChangeRef = useRef(onChange)
+  const completionSourceRef = useRef(completionSource)
+  const cursorHandlerRef = useRef(onCursorActivity)
+  onChangeRef.current = onChange
+  completionSourceRef.current = completionSource
+  cursorHandlerRef.current = onCursorActivity
+
+  const readOnlyCompartment = useRef(new Compartment())
+  const decorationsCompartment = useRef(new Compartment())
+
+  useEffect(() => {
+    const parent = parentRef.current
+    if (!parent) {
+      return undefined
+    }
+    const baseExtensions = buildBaseExtensions({
+      showLineNumbers,
+      fontSizePx: fontSize,
+      getCompletionSource: () => completionSourceRef.current,
+      getCursorHandler: () => cursorHandlerRef.current
+    })
+    const extensions: Extension[] = [
+      ...baseExtensions,
+      ...(placeholder ? [placeholderExtension(placeholder)] : []),
+      EditorView.theme({
+        '.cm-scroller': {
+          minHeight: toCssSize(minHeight) ?? EMPTY_STRING,
+          maxHeight: toCssSize(maxHeight) ?? EMPTY_STRING
+        }
+      }),
+      readOnlyCompartment.current.of(readOnlyExtension(readOnly)),
+      decorationsCompartment.current.of(decorationsPlugin(decorations)),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          onChangeRef.current?.(update.state.doc.toString())
+        }
+      })
+    ]
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({ doc: value, extensions })
+    })
+    viewRef.current = view
+    if (autoFocus && !readOnly) {
+      view.focus()
+    }
+    return () => {
+      view.destroy()
+      viewRef.current = null
+    }
+    // Built once; prop changes are applied through compartments/effects below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: readOnlyCompartment.current.reconfigure(
+        readOnlyExtension(readOnly)
+      )
+    })
+  }, [readOnly])
+
+  useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: decorationsCompartment.current.reconfigure(
+        decorationsPlugin(decorations)
+      )
+    })
+  }, [decorations])
+
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) {
+      return
+    }
+    const current = view.state.doc.toString()
+    if (current !== value) {
+      view.dispatch({
+        changes: { from: 0, to: current.length, insert: value }
+      })
+    }
+  }, [value])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => viewRef.current?.focus(),
+      insert: (text, options) => {
+        const view = viewRef.current
+        if (!view) {
+          return
+        }
+        const { from, to } = view.state.selection.main
+        const caret = from + text.length - (options?.cursorOffsetFromEnd ?? 0)
+        view.dispatch({
+          changes: { from, to, insert: text },
+          selection: { anchor: caret }
+        })
+        view.focus()
+      },
+      startCompletion: () => {
+        const view = viewRef.current
+        if (view) {
+          startCompletion(view)
+        }
+      }
+    }),
+    []
+  )
+
+  return (
+    <div
+      ref={parentRef}
+      className={clsx(styles.jsonEditor, extraClass)}
+      data-testid={dataTestId}
+    />
+  )
+})

--- a/lib/v2/components/JsonEditor/index.ts
+++ b/lib/v2/components/JsonEditor/index.ts
@@ -1,0 +1,11 @@
+export { JsonEditor, type JsonEditorProps } from './JsonEditor'
+export type {
+  JsonEditorCompletion,
+  JsonEditorCompletionContext,
+  JsonEditorCompletionResult,
+  JsonEditorCompletionSource,
+  JsonEditorCursorContext,
+  JsonEditorDecoration,
+  JsonEditorHandle,
+  JsonEditorInsertOptions
+} from './types'

--- a/lib/v2/components/JsonEditor/jsonEditor.module.scss
+++ b/lib/v2/components/JsonEditor/jsonEditor.module.scss
@@ -1,0 +1,22 @@
+.jsonEditor {
+  --cm-selection-bg: color-mix(in sRGB, var(--blue-500) 32%, transparent);
+  --cm-selection-match-bg: color-mix(in sRGB, var(--blue-500) 18%, transparent);
+
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--gray-50-950);
+
+  :global(.cm-editor) {
+    height: 100%;
+  }
+}
+
+:global(.v2-dark-mode) .jsonEditor,
+:global([data-theme='dark']) .jsonEditor,
+:global(.dark-mode) .jsonEditor,
+:global(body.dark-mode) .jsonEditor {
+  --cm-selection-bg: color-mix(in sRGB, var(--blue-300-700) 50%, transparent);
+  --cm-selection-match-bg: color-mix(in sRGB, var(--blue-300-700) 28%, transparent);
+}

--- a/lib/v2/components/JsonEditor/jsonEditorSetup.ts
+++ b/lib/v2/components/JsonEditor/jsonEditorSetup.ts
@@ -32,6 +32,7 @@ import {
   highlightActiveLineGutter,
   keymap,
   lineNumbers,
+  placeholder as placeholderExtension,
   ViewPlugin,
   type ViewUpdate
 } from '@codemirror/view'
@@ -51,8 +52,9 @@ const SELECTION_BG =
 const SELECTION_BG_IMPORTANT = `${SELECTION_BG} !important`
 const SELECTION_MATCH_BG =
   'var(--cm-selection-match-bg, color-mix(in sRGB, var(--blue-500) 18%, transparent))'
-/** Selected autocomplete row — solid, since rows have their own contrast. */
-const ROW_SELECTED_BG = 'var(--gray-200-800)'
+/** Autocomplete: fuchsia key labels over a neutral row-hover background. */
+const KEY_COLOR = 'var(--fuchsia-600-400)'
+const ROW_HOVER_BG = 'var(--gray-200-800)'
 
 /**
  * JSON syntax colors (WEKA palette): fuchsia keys, grayscale values and
@@ -120,13 +122,16 @@ function baseTheme(fontSizePx: number): Extension {
       color: TEXT_COLOR,
       boxShadow: '0 6px 16px rgb(0 0 0 / 35%)'
     },
-    '.cm-tooltip-autocomplete > ul > li[aria-selected]': {
-      backgroundColor: ROW_SELECTED_BG,
-      color: TEXT_COLOR
-    },
     '.cm-tooltip-autocomplete > ul > li': {
       fontFamily: MONO_FONT,
       padding: '2px 8px'
+    },
+    '.cm-tooltip-autocomplete > ul > li[aria-selected], .cm-tooltip-autocomplete > ul > li:hover':
+      { backgroundColor: ROW_HOVER_BG },
+    '.cm-completionLabel': { color: KEY_COLOR },
+    '.cm-completionMatchedText': {
+      color: 'inherit',
+      textDecoration: 'none'
     },
     '.cm-completionDetail': {
       marginLeft: '2ch',
@@ -255,36 +260,45 @@ function completionAdapter(
  * Notifies the caller of cursor/selection/scroll changes with the surrounding
  * document text and the caret's viewport coordinates — enough to position an
  * external affordance (e.g. an insert button) without touching the engine.
+ * Scrolling moves the caret's screen position without changing the selection,
+ * so both view updates and raw scroll events re-emit the coordinates.
  */
 function cursorActivityPlugin(
   getHandler: () => ((context: JsonEditorCursorContext) => void) | undefined
 ): Extension {
-  return EditorView.updateListener.of((update: ViewUpdate) => {
+  const emit = (view: EditorView) => {
     const handler = getHandler()
     if (!handler) {
       return
     }
-    const scrolled = update.transactions.some((tr) => tr.isUserEvent('select'))
-    if (
-      !update.selectionSet &&
-      !update.docChanged &&
-      !update.focusChanged &&
-      !scrolled &&
-      !update.geometryChanged
-    ) {
-      return
-    }
-    const { state, view } = update
-    const head = state.selection.main.head
+    const head = view.state.selection.main.head
     const rect = view.coordsAtPos(head)
     handler({
-      textBefore: state.doc.sliceString(0, head),
-      textAfter: state.doc.sliceString(head),
+      textBefore: view.state.doc.sliceString(0, head),
+      textAfter: view.state.doc.sliceString(head),
       coords: rect
         ? { left: rect.left, top: rect.top, bottom: rect.bottom }
         : null
     })
-  })
+  }
+  return [
+    EditorView.updateListener.of((update: ViewUpdate) => {
+      if (
+        update.selectionSet ||
+        update.docChanged ||
+        update.focusChanged ||
+        update.geometryChanged ||
+        update.viewportChanged
+      ) {
+        emit(update.view)
+      }
+    }),
+    EditorView.domEventHandlers({
+      scroll: (_event, view) => {
+        emit(view)
+      }
+    })
+  ]
 }
 
 /**
@@ -314,22 +328,22 @@ function foldMarkerDOM(open: boolean): HTMLElement {
   return marker
 }
 
-export interface JsonEditorExtensionsConfig {
-  fontSizePx: number
-  showLineNumbers: boolean
+export interface JsonEditorStaticConfig {
   getCompletionSource: () => JsonEditorCompletionSource | undefined
   getCursorHandler: () =>
     | ((context: JsonEditorCursorContext) => void)
     | undefined
 }
 
-export function buildBaseExtensions(
-  config: JsonEditorExtensionsConfig
+/**
+ * Extensions that never change for the editor's lifetime (language, history,
+ * keymaps, selection, autocomplete, cursor tracking). Kept out of any
+ * compartment so reconfiguring layout props doesn't reset document history.
+ */
+export function buildStaticExtensions(
+  config: JsonEditorStaticConfig
 ): Extension[] {
   return [
-    ...(config.showLineNumbers
-      ? [lineNumbers(), foldGutter({ markerDOM: foldMarkerDOM })]
-      : []),
     highlightActiveLine(),
     highlightActiveLineGutter(),
     drawSelection(),
@@ -348,8 +362,49 @@ export function buildBaseExtensions(
       ...searchKeymap,
       ...foldKeymap,
       ...completionKeymap
-    ]),
-    baseTheme(config.fontSizePx)
+    ])
+  ]
+}
+
+function toCssSize(size: number | string | undefined): string | undefined {
+  if (size === undefined) {
+    return undefined
+  }
+  return typeof size === 'number' ? `${size}px` : size
+}
+
+export interface JsonEditorLayoutConfig {
+  fontSizePx: number
+  showLineNumbers: boolean
+  placeholder: string
+  minHeight?: number | string
+  maxHeight?: number | string
+}
+
+/**
+ * Layout/chrome extensions driven by props that may change at runtime
+ * (font size, gutter, placeholder, height bounds). Held in a compartment so
+ * they can be reconfigured without recreating the editor or its state.
+ */
+export function buildLayoutExtensions(
+  config: JsonEditorLayoutConfig
+): Extension {
+  const scroller: Record<string, string> = {}
+  const minHeight = toCssSize(config.minHeight)
+  const maxHeight = toCssSize(config.maxHeight)
+  if (minHeight !== undefined) {
+    scroller.minHeight = minHeight
+  }
+  if (maxHeight !== undefined) {
+    scroller.maxHeight = maxHeight
+  }
+  return [
+    ...(config.showLineNumbers
+      ? [lineNumbers(), foldGutter({ markerDOM: foldMarkerDOM })]
+      : []),
+    baseTheme(config.fontSizePx),
+    ...(config.placeholder ? [placeholderExtension(config.placeholder)] : []),
+    EditorView.theme({ '.cm-scroller': scroller })
   ]
 }
 

--- a/lib/v2/components/JsonEditor/jsonEditorSetup.ts
+++ b/lib/v2/components/JsonEditor/jsonEditorSetup.ts
@@ -1,0 +1,356 @@
+import type {
+  JsonEditorCompletionSource,
+  JsonEditorCursorContext,
+  JsonEditorDecoration
+} from './types'
+import type { Extension } from '@codemirror/state'
+
+import {
+  autocompletion,
+  type CompletionContext,
+  completionKeymap,
+  type CompletionResult
+} from '@codemirror/autocomplete'
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
+import { json } from '@codemirror/lang-json'
+import {
+  bracketMatching,
+  foldGutter,
+  foldKeymap,
+  HighlightStyle,
+  indentOnInput,
+  syntaxHighlighting
+} from '@codemirror/language'
+import { highlightSelectionMatches, searchKeymap } from '@codemirror/search'
+import { RangeSetBuilder } from '@codemirror/state'
+import {
+  Decoration,
+  type DecorationSet,
+  drawSelection,
+  EditorView,
+  highlightActiveLine,
+  highlightActiveLineGutter,
+  keymap,
+  lineNumbers,
+  ViewPlugin,
+  type ViewUpdate
+} from '@codemirror/view'
+import { tags } from '@lezer/highlight'
+
+const MONO_FONT = "'IBM Plex Mono', 'IBM Plex Sans', monospace"
+const TEXT_COLOR = 'var(--gray-950-20)'
+const TRANSPARENT = 'transparent'
+const VALUE_COLOR = 'var(--gray-900-100)'
+/**
+ * Selection colors come from theme-aware CSS variables set in the SCSS module
+ * (bright blue in light, deeper blue in dark); the fallbacks keep a sensible
+ * translucent blue if a consumer renders the editor without that module.
+ */
+const SELECTION_BG =
+  'var(--cm-selection-bg, color-mix(in sRGB, var(--blue-500) 32%, transparent))'
+const SELECTION_BG_IMPORTANT = `${SELECTION_BG} !important`
+const SELECTION_MATCH_BG =
+  'var(--cm-selection-match-bg, color-mix(in sRGB, var(--blue-500) 18%, transparent))'
+/** Selected autocomplete row — solid, since rows have their own contrast. */
+const ROW_SELECTED_BG = 'var(--gray-200-800)'
+
+/**
+ * JSON syntax colors (WEKA palette): fuchsia keys, grayscale values and
+ * punctuation. References the consumer's v2 theme tokens so light/dark flip.
+ */
+const jsonHighlightStyle = HighlightStyle.define([
+  { tag: tags.propertyName, color: 'var(--fuchsia-600-400)' },
+  { tag: [tags.string, tags.special(tags.string)], color: VALUE_COLOR },
+  { tag: [tags.number, tags.bool, tags.null], color: VALUE_COLOR },
+  { tag: [tags.punctuation, tags.separator], color: 'var(--gray-700-300)' },
+  { tag: tags.invalid, color: 'var(--red-500)' }
+])
+
+/**
+ * Editor chrome (background, gutter, selection, cursor, autocomplete popup).
+ * Colors reference the consumer's v2 theme tokens so light/dark flip for free.
+ */
+function baseTheme(fontSizePx: number): Extension {
+  return EditorView.theme({
+    '&': {
+      color: TEXT_COLOR,
+      backgroundColor: TRANSPARENT,
+      fontSize: `${fontSizePx}px`,
+      height: '100%'
+    },
+    '.cm-content': {
+      fontFamily: MONO_FONT,
+      caretColor: TEXT_COLOR
+    },
+    '.cm-scroller': { fontFamily: MONO_FONT, overflow: 'auto' },
+    '&.cm-focused': { outline: 'none' },
+    '.cm-gutters': {
+      backgroundColor: TRANSPARENT,
+      color: 'var(--gray-500)',
+      border: 'none',
+      fontSize: '12px'
+    },
+    '.cm-lineNumbers .cm-gutterElement': { padding: '0 3px 0 8px' },
+    '.cm-foldGutter .cm-gutterElement': {
+      padding: '0 4px',
+      color: 'var(--gray-500)'
+    },
+    '.cm-foldMarker': {
+      display: 'inline-block',
+      fontSize: '11px',
+      lineHeight: '1',
+      transition: 'transform 0.1s ease'
+    },
+    '.cm-activeLine': { backgroundColor: 'var(--gray-100-900)' },
+    '.cm-activeLineGutter': { backgroundColor: 'var(--gray-100-900)' },
+    '.cm-cursor, .cm-dropCursor': { borderLeftColor: TEXT_COLOR },
+    '.cm-selectionBackground': { backgroundColor: SELECTION_BG_IMPORTANT },
+    '&.cm-focused .cm-selectionBackground': {
+      backgroundColor: SELECTION_BG_IMPORTANT
+    },
+    '.cm-content ::selection, .cm-line::selection': {
+      backgroundColor: SELECTION_BG_IMPORTANT,
+      color: TEXT_COLOR
+    },
+    '.cm-selectionMatch': { backgroundColor: SELECTION_MATCH_BG },
+    '.cm-tooltip': {
+      border: '1px solid var(--gray-200-800)',
+      borderRadius: '8px',
+      backgroundColor: 'var(--gray-50-950)',
+      color: TEXT_COLOR,
+      boxShadow: '0 6px 16px rgb(0 0 0 / 35%)'
+    },
+    '.cm-tooltip-autocomplete > ul > li[aria-selected]': {
+      backgroundColor: ROW_SELECTED_BG,
+      color: TEXT_COLOR
+    },
+    '.cm-tooltip-autocomplete > ul > li': {
+      fontFamily: MONO_FONT,
+      padding: '2px 8px'
+    },
+    '.cm-completionDetail': {
+      marginLeft: '2ch',
+      fontStyle: 'italic',
+      opacity: '0.65'
+    }
+  })
+}
+
+interface CollectedMatch {
+  from: number
+  to: number
+  className: string
+}
+
+function collectMatches(
+  text: string,
+  offset: number,
+  rules: JsonEditorDecoration[]
+): CollectedMatch[] {
+  const matches: CollectedMatch[] = []
+  for (const rule of rules) {
+    const flags = rule.pattern.flags.includes('g')
+      ? rule.pattern.flags
+      : `${rule.pattern.flags}g`
+    const regex = new RegExp(rule.pattern.source, flags)
+    let match = regex.exec(text)
+    while (match !== null) {
+      const className =
+        typeof rule.className === 'function'
+          ? rule.className(match[0])
+          : rule.className
+      matches.push({
+        from: offset + match.index,
+        to: offset + match.index + match[0].length,
+        className
+      })
+      if (match.index === regex.lastIndex) {
+        regex.lastIndex += 1
+      }
+      match = regex.exec(text)
+    }
+  }
+  return matches
+}
+
+/**
+ * Applies caller-supplied regex decorations to the visible text. Matches are
+ * sorted and overlaps dropped so the RangeSetBuilder receives ordered,
+ * non-overlapping ranges. Rebuilt on every doc/viewport change.
+ */
+function decorationsPlugin(rules: JsonEditorDecoration[]): Extension {
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet
+
+      constructor(view: EditorView) {
+        this.decorations = this.build(view)
+      }
+
+      update(update: ViewUpdate) {
+        if (update.docChanged || update.viewportChanged) {
+          this.decorations = this.build(update.view)
+        }
+      }
+
+      build(view: EditorView): DecorationSet {
+        const matches: CollectedMatch[] = []
+        for (const { from, to } of view.visibleRanges) {
+          matches.push(
+            ...collectMatches(view.state.doc.sliceString(from, to), from, rules)
+          )
+        }
+        matches.sort((a, b) => a.from - b.from || a.to - b.to)
+        const builder = new RangeSetBuilder<Decoration>()
+        let lastTo = -1
+        for (const { from, to, className } of matches) {
+          if (from < lastTo) {
+            continue
+          }
+          builder.add(from, to, Decoration.mark({ class: className }))
+          lastTo = to
+        }
+        return builder.finish()
+      }
+    },
+    { decorations: (plugin) => plugin.decorations }
+  )
+}
+
+/**
+ * Bridges the caller's plain-text completion source to CodeMirror's
+ * autocomplete. The source receives the document text on either side of the
+ * cursor (no engine types) and returns an absolute `from` offset plus options.
+ */
+function completionAdapter(
+  getSource: () => JsonEditorCompletionSource | undefined
+): Extension {
+  const source = (context: CompletionContext): CompletionResult | null => {
+    const resolve = getSource()
+    if (!resolve) {
+      return null
+    }
+    const result = resolve({
+      textBefore: context.state.doc.sliceString(0, context.pos),
+      textAfter: context.state.doc.sliceString(context.pos),
+      explicit: context.explicit
+    })
+    if (!result || result.options.length === 0) {
+      return null
+    }
+    return {
+      from: result.from,
+      options: result.options.map((option) => ({
+        label: option.label,
+        detail: option.detail,
+        info: option.info,
+        apply: option.apply ?? option.label
+      }))
+    }
+  }
+  return autocompletion({ override: [source], icons: false })
+}
+
+/**
+ * Notifies the caller of cursor/selection/scroll changes with the surrounding
+ * document text and the caret's viewport coordinates — enough to position an
+ * external affordance (e.g. an insert button) without touching the engine.
+ */
+function cursorActivityPlugin(
+  getHandler: () => ((context: JsonEditorCursorContext) => void) | undefined
+): Extension {
+  return EditorView.updateListener.of((update: ViewUpdate) => {
+    const handler = getHandler()
+    if (!handler) {
+      return
+    }
+    const scrolled = update.transactions.some((tr) => tr.isUserEvent('select'))
+    if (
+      !update.selectionSet &&
+      !update.docChanged &&
+      !update.focusChanged &&
+      !scrolled &&
+      !update.geometryChanged
+    ) {
+      return
+    }
+    const { state, view } = update
+    const head = state.selection.main.head
+    const rect = view.coordsAtPos(head)
+    handler({
+      textBefore: state.doc.sliceString(0, head),
+      textAfter: state.doc.sliceString(head),
+      coords: rect
+        ? { left: rect.left, top: rect.top, bottom: rect.bottom }
+        : null
+    })
+  })
+}
+
+/**
+ * Blocks macOS text substitutions (smart quotes, double-space period) that
+ * reach the contenteditable as `insertReplacementText` and would corrupt JSON.
+ */
+const blockTextSubstitution = EditorView.domEventHandlers({
+  beforeinput(event) {
+    if (event.inputType === 'insertReplacementText') {
+      event.preventDefault()
+      return true
+    }
+    return false
+  }
+})
+
+/**
+ * A single disclosure chevron for the fold gutter: points right when folded,
+ * rotated down when open — consistent regardless of fold state.
+ */
+function foldMarkerDOM(open: boolean): HTMLElement {
+  const marker = document.createElement('span')
+  marker.className = 'cm-foldMarker'
+  marker.setAttribute('aria-hidden', 'true')
+  marker.textContent = '›'
+  marker.style.transform = open ? 'rotate(90deg)' : 'none'
+  return marker
+}
+
+export interface JsonEditorExtensionsConfig {
+  fontSizePx: number
+  showLineNumbers: boolean
+  getCompletionSource: () => JsonEditorCompletionSource | undefined
+  getCursorHandler: () =>
+    | ((context: JsonEditorCursorContext) => void)
+    | undefined
+}
+
+export function buildBaseExtensions(
+  config: JsonEditorExtensionsConfig
+): Extension[] {
+  return [
+    ...(config.showLineNumbers
+      ? [lineNumbers(), foldGutter({ markerDOM: foldMarkerDOM })]
+      : []),
+    highlightActiveLine(),
+    highlightActiveLineGutter(),
+    drawSelection(),
+    history(),
+    indentOnInput(),
+    bracketMatching(),
+    highlightSelectionMatches(),
+    json(),
+    syntaxHighlighting(jsonHighlightStyle),
+    completionAdapter(config.getCompletionSource),
+    cursorActivityPlugin(config.getCursorHandler),
+    blockTextSubstitution,
+    keymap.of([
+      ...defaultKeymap,
+      ...historyKeymap,
+      ...searchKeymap,
+      ...foldKeymap,
+      ...completionKeymap
+    ]),
+    baseTheme(config.fontSizePx)
+  ]
+}
+
+export { decorationsPlugin }

--- a/lib/v2/components/JsonEditor/types.ts
+++ b/lib/v2/components/JsonEditor/types.ts
@@ -1,0 +1,72 @@
+/** A single autocomplete suggestion offered by a {@link JsonEditorCompletionSource}. */
+export interface JsonEditorCompletion {
+  /** Text shown in the popup and inserted unless {@link apply} overrides it. */
+  label: string
+  /** Muted text shown to the right of the label (e.g. a short description). */
+  detail?: string
+  /** Longer text shown in the details panel when the option is highlighted. */
+  info?: string
+  /** Text inserted on accept, when it differs from {@link label}. */
+  apply?: string
+}
+
+/** Result returned by a {@link JsonEditorCompletionSource}. */
+export interface JsonEditorCompletionResult {
+  /** Absolute document offset where the inserted text replaces from. */
+  from: number
+  options: JsonEditorCompletion[]
+}
+
+/** Document context handed to a completion source, free of engine types. */
+export interface JsonEditorCompletionContext {
+  /** Whole document text before the cursor (its length is the cursor offset). */
+  textBefore: string
+  /** Whole document text after the cursor. */
+  textAfter: string
+  /** True when completion was requested explicitly (not while typing). */
+  explicit: boolean
+}
+
+/**
+ * Produces completions for the cursor position, or `null` to offer none. The
+ * caller owns all domain logic (what to suggest, where, how to filter).
+ */
+export type JsonEditorCompletionSource = (
+  context: JsonEditorCompletionContext
+) => JsonEditorCompletionResult | null
+
+/**
+ * A regex-driven text decoration. Every match in the visible text is wrapped
+ * in a span carrying {@link className} (a global class the consumer styles).
+ * `className` may be a function of the matched text for per-match styling.
+ */
+export interface JsonEditorDecoration {
+  pattern: RegExp
+  className: string | ((match: string) => string)
+}
+
+/** Cursor state reported by {@link JsonEditorProps.onCursorActivity}. */
+export interface JsonEditorCursorContext {
+  textBefore: string
+  textAfter: string
+  /** Caret viewport coordinates (as `getBoundingClientRect`), null if off-screen. */
+  coords: { left: number; top: number; bottom: number } | null
+}
+
+/** Options for {@link JsonEditorHandle.insert}. */
+export interface JsonEditorInsertOptions {
+  /**
+   * Move the caret left by this many characters after inserting, so it lands
+   * inside the inserted text (e.g. between wrapping quotes).
+   */
+  cursorOffsetFromEnd?: number
+}
+
+/** Imperative handle exposed via `ref`. */
+export interface JsonEditorHandle {
+  focus: () => void
+  /** Replace the selection with `text`, then optionally reposition the caret. */
+  insert: (text: string, options?: JsonEditorInsertOptions) => void
+  /** Open the autocomplete popup at the current cursor. */
+  startCompletion: () => void
+}

--- a/lib/v2/components/index.ts
+++ b/lib/v2/components/index.ts
@@ -220,6 +220,18 @@ export type { TextAreaProps } from './inputs/TextArea'
 export { TextArea } from './inputs/TextArea'
 export type { TextInputProps, TextInputType } from './inputs/TextInput'
 export { TEXT_INPUT_TYPES, TextInput } from './inputs/TextInput'
+export type {
+  JsonEditorCompletion,
+  JsonEditorCompletionContext,
+  JsonEditorCompletionResult,
+  JsonEditorCompletionSource,
+  JsonEditorCursorContext,
+  JsonEditorDecoration,
+  JsonEditorHandle,
+  JsonEditorInsertOptions,
+  JsonEditorProps
+} from './JsonEditor'
+export { JsonEditor } from './JsonEditor'
 export type { LoadingStateProps, StateType } from './LoadingState'
 export { LoadingState, STATE_TYPES } from './LoadingState'
 export type { LoginFieldProps, LoginFieldType } from './LoginField'

--- a/package.json
+++ b/package.json
@@ -70,6 +70,14 @@
     "./lib/*": "./lib/*"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6",
+    "@codemirror/commands": "^6",
+    "@codemirror/lang-json": "^6",
+    "@codemirror/language": "^6",
+    "@codemirror/search": "^6",
+    "@codemirror/state": "^6",
+    "@codemirror/view": "^6",
+    "@lezer/highlight": "^1",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.23",
     "ace-builds": "^1.43.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2923,6 +2923,86 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codemirror/autocomplete@npm:^6":
+  version: 6.20.3
+  resolution: "@codemirror/autocomplete@npm:6.20.3"
+  dependencies:
+    "@codemirror/language": "npm:^6.0.0"
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.17.0"
+    "@lezer/common": "npm:^1.0.0"
+  checksum: 10c0/c8aa358d25cde007a7073fb39fd268d1908aa0f664047cc44af0f7a6b2835f227c9bd60f0c7cde5914cf2c9ef9c014fee6e322832e83d9f1c1b55872d2300b69
+  languageName: node
+  linkType: hard
+
+"@codemirror/commands@npm:^6":
+  version: 6.10.4
+  resolution: "@codemirror/commands@npm:6.10.4"
+  dependencies:
+    "@codemirror/language": "npm:^6.0.0"
+    "@codemirror/state": "npm:^6.7.0"
+    "@codemirror/view": "npm:^6.27.0"
+    "@lezer/common": "npm:^1.1.0"
+  checksum: 10c0/ae47b633afc68b6854111d9749d5f8dde16a13e5053ec72b4a0c5fe0cc553c490040b05c6d8e5d1670e1a2612cc6ef406b9e51578593d030c7f44a0ad46e6f94
+  languageName: node
+  linkType: hard
+
+"@codemirror/lang-json@npm:^6":
+  version: 6.0.2
+  resolution: "@codemirror/lang-json@npm:6.0.2"
+  dependencies:
+    "@codemirror/language": "npm:^6.0.0"
+    "@lezer/json": "npm:^1.0.0"
+  checksum: 10c0/4a36022226557d0571c143f907638eb2d46c0f7cf96c6d9a86dac397a789efa2b387e3dd3df94bac21e27692892443b24f8129c044c9012df66e68f5080745b0
+  languageName: node
+  linkType: hard
+
+"@codemirror/language@npm:^6, @codemirror/language@npm:^6.0.0":
+  version: 6.12.4
+  resolution: "@codemirror/language@npm:6.12.4"
+  dependencies:
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.23.0"
+    "@lezer/common": "npm:^1.5.0"
+    "@lezer/highlight": "npm:^1.0.0"
+    "@lezer/lr": "npm:^1.0.0"
+    style-mod: "npm:^4.0.0"
+  checksum: 10c0/1b704a66f618d96eddf5937a41996e1ab42a70b5333a90b768e5539c25b7ab822e91a93e66b14d47a886cd73b3e3e22ddf77b8f11fb2f496ebd7ba010f3c4deb
+  languageName: node
+  linkType: hard
+
+"@codemirror/search@npm:^6":
+  version: 6.7.1
+  resolution: "@codemirror/search@npm:6.7.1"
+  dependencies:
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.37.0"
+    crelt: "npm:^1.0.5"
+  checksum: 10c0/2930c4139340da4b52f217dc0a7040e36aa122279911894ebb06c5ea7364d91e73c8e195db5610caa9474ef45a99552ad944a416fa9c381a336f1f39bf0e71ad
+  languageName: node
+  linkType: hard
+
+"@codemirror/state@npm:^6, @codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.7.0":
+  version: 6.7.1
+  resolution: "@codemirror/state@npm:6.7.1"
+  dependencies:
+    "@marijn/find-cluster-break": "npm:^1.0.0"
+  checksum: 10c0/2490b87759d1f4f27f4573a084414bf30bf9ed5dccaa75485334a2d132c039f2255e3bca564fb07c6760a16bf86cc29532475d9fb75cfdb0771b330fe71be4e7
+  languageName: node
+  linkType: hard
+
+"@codemirror/view@npm:^6, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.27.0, @codemirror/view@npm:^6.37.0":
+  version: 6.43.6
+  resolution: "@codemirror/view@npm:6.43.6"
+  dependencies:
+    "@codemirror/state": "npm:^6.7.0"
+    crelt: "npm:^1.0.6"
+    style-mod: "npm:^4.1.0"
+    w3c-keyname: "npm:^2.2.4"
+  checksum: 10c0/930b043b8d48e02421a1cb15eb311fb39edbb9709a107eeea8de133aad8ab3fb9bbfae9e829216914cb997026d06d26a71768ff0e2a8d679c9d27d3cb1b940eb
+  languageName: node
+  linkType: hard
+
 "@csstools/color-helpers@npm:^5.1.0":
   version: 5.1.0
   resolution: "@csstools/color-helpers@npm:5.1.0"
@@ -3832,6 +3912,49 @@ __metadata:
   version: 1.1.1
   resolution: "@keyv/serialize@npm:1.1.1"
   checksum: 10c0/b0008cae4a54400c3abf587b8cc2474c6f528ee58969ce6cf9cb07a04006f80c73c85971d6be6544408318a2bc40108236a19a82aea0a6de95aae49533317374
+  languageName: node
+  linkType: hard
+
+"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.1.0, @lezer/common@npm:^1.2.0, @lezer/common@npm:^1.3.0, @lezer/common@npm:^1.5.0":
+  version: 1.5.2
+  resolution: "@lezer/common@npm:1.5.2"
+  checksum: 10c0/e39b46d74899409eab549df7942f00cd8c7f46c81ef0e2f079654ca96d262fca009927328bcd500d69270f5f09986e74768bed19c0acaadbd22f1a6c7dd9bd85
+  languageName: node
+  linkType: hard
+
+"@lezer/highlight@npm:^1, @lezer/highlight@npm:^1.0.0":
+  version: 1.2.3
+  resolution: "@lezer/highlight@npm:1.2.3"
+  dependencies:
+    "@lezer/common": "npm:^1.3.0"
+  checksum: 10c0/3bcb4fce7a1a45b5973895d7cb2be47970a0098700f2a0970aef9878ffd37f540285a2d7388ec1f524726ec90cc5196b5701bbb9764b7e7300786d772b7d2ce2
+  languageName: node
+  linkType: hard
+
+"@lezer/json@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@lezer/json@npm:1.0.3"
+  dependencies:
+    "@lezer/common": "npm:^1.2.0"
+    "@lezer/highlight": "npm:^1.0.0"
+    "@lezer/lr": "npm:^1.0.0"
+  checksum: 10c0/e91c957cc0825e927b55fbcd233d7ee0b39f9c2a89d9475489f394b7eba2b59e5f480d157a12d5cd6ae6f14bc99f9ccd8e8113baad498199ef1b13c49105f546
+  languageName: node
+  linkType: hard
+
+"@lezer/lr@npm:^1.0.0":
+  version: 1.4.10
+  resolution: "@lezer/lr@npm:1.4.10"
+  dependencies:
+    "@lezer/common": "npm:^1.0.0"
+  checksum: 10c0/15fac0ecc02a57f111432808c89f7cfb9fed0d78d0a98742607acb5859220a9c18526dd6d509d9fe17f5ef762aa73ce29fa6b930739abb857c1df8949a9003ea
+  languageName: node
+  linkType: hard
+
+"@marijn/find-cluster-break@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@marijn/find-cluster-break@npm:1.0.3"
+  checksum: 10c0/6242963048452653d664beacbb3d27e9b3fe58c029328a561ec26ed88356508ebf4f1d94f6412b583399cab0055eb7ca1f97de62ebf865730573bcadc3a381a0
   languageName: node
   linkType: hard
 
@@ -6495,10 +6618,18 @@ __metadata:
     "@babel/preset-react": "npm:^7.28.5"
     "@babel/preset-typescript": "npm:^7.28.5"
     "@chromatic-com/storybook": "npm:^2.0.2"
+    "@codemirror/autocomplete": "npm:^6"
+    "@codemirror/commands": "npm:^6"
+    "@codemirror/lang-json": "npm:^6"
+    "@codemirror/language": "npm:^6"
+    "@codemirror/search": "npm:^6"
+    "@codemirror/state": "npm:^6"
+    "@codemirror/view": "npm:^6"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
     "@eslint/compat": "npm:^1.2.9"
     "@eslint/js": "npm:^9.0.0"
+    "@lezer/highlight": "npm:^1"
     "@mui/material": "npm:^6.5.0"
     "@storybook/addon-actions": "npm:^8.6.14"
     "@storybook/addon-essentials": "npm:^8.6.14"
@@ -7951,6 +8082,13 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/a5d4d95599687532ee072bca60170133c24d4e08cd795529e0f22c6ce5fde9409eaf4f26e36e3d671f43270ef858fc68f3c7b0ec28e58fac7ddebda5b7725306
+  languageName: node
+  linkType: hard
+
+"crelt@npm:^1.0.5, crelt@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "crelt@npm:1.0.7"
+  checksum: 10c0/5fdb5fcfa492a176c4cdaac611c131a183a91f2e6e3ea2ba2111b6891ca75bb7ba1ef81d67dab34387f5553c415d8a3d776690d3cf3ee68fca2dd3bfbed382e9
   languageName: node
   linkType: hard
 
@@ -15733,6 +15871,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"style-mod@npm:^4.0.0, style-mod@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "style-mod@npm:4.1.3"
+  checksum: 10c0/36059006ea73cd96242ca8be06b625522d488bf8caca9c18436edf77092183381f08109577a4b3d35482f3395231099f195dbc854a46ce507fbf75c484f2cfcc
+  languageName: node
+  linkType: hard
+
 "style-to-js@npm:^1.0.0":
   version: 1.1.16
   resolution: "style-to-js@npm:1.1.16"
@@ -17155,6 +17300,13 @@ __metadata:
   version: 3.0.8
   resolution: "vscode-uri@npm:3.0.8"
   checksum: 10c0/f7f217f526bf109589969fe6e66b71e70b937de1385a1d7bb577ca3ee7c5e820d3856a86e9ff2fa9b7a0bc56a3dd8c3a9a557d3fedd7df414bc618d5e6b567f9
+  languageName: node
+  linkType: hard
+
+"w3c-keyname@npm:^2.2.4":
+  version: 2.2.8
+  resolution: "w3c-keyname@npm:2.2.8"
+  checksum: 10c0/37cf335c90efff31672ebb345577d681e2177f7ff9006a9ad47c68c5a9d265ba4a7b39d6c2599ceea639ca9315584ce4bd9c9fbf7a7217bfb7a599e71943c4c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a **`JsonEditor`** component to the v2 component set (`@weka/weka-ui-components/v2`), built on **CodeMirror 6**. It replaces ad-hoc Ace-based JSON editing/viewing in consumers (starting with Observe's webhook payload editor and the event/alert detail viewers under WH-4209).

Placed at the top level of `lib/v2/components/` (alongside `Table`, `Tabs`), not under `inputs/` — it's a code editor, not a form-field primitive.

## What it does

- JSON syntax highlighting (WEKA palette: fuchsia keys, grayscale values), code folding, search, and a **read-only viewer** mode.
- **Decoupled, engine-free API** so consumers own their domain logic:
  - `completionSource` — receives plain text before/after the cursor, returns `{ from, options }`; no CodeMirror types leak to callers.
  - `decorations` — regex → className (static or per-match), for things like template-variable tokens.
  - `onCursorActivity` + imperative handle (`focus` / `insert` / `startCompletion`) for positioning external affordances (e.g. an insert button).
- Theme-aware: all colors reference v2 theme tokens so they flip light/dark, including a legible, theme-appropriate text selection.

## Dependencies

Adds `@codemirror/{state,view,language,lang-json,autocomplete,commands,search}` and `@lezer/highlight`. They are externalized in the v2 build (consumers resolve them from their own tree), consistent with the other v2 deps.

## Testing

- Unit tests (`JsonEditor.test.tsx`) — rendering, value sync, read-only, decorations, imperative insert. All pass.
- Storybook story (`v2/JsonEditor`) with editable + read-only demos.
- `yarn build` produces the declarations and externalizes CodeMirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)