### PR TITLE
fix(tooltip): keep tooltip content mounted across re-renders

### DIFF
--- a/lib/components/Tooltip/Tooltip.tsx
+++ b/lib/components/Tooltip/Tooltip.tsx
@@ -1,9 +1,9 @@
 import type { TooltipProps as MuiTooltipProps } from '@mui/material'
-import type { ForwardedRef, ReactElement } from 'react'
+import type { ReactElement } from 'react'
 
-import React from 'react'
 import { Tooltip as MuiTooltip } from '@mui/material'
 import clsx from 'clsx'
+
 import { EMPTY_STRING } from '#consts'
 
 import Markdown from '../Markdown'
@@ -40,38 +40,27 @@ function Tooltip({
     return children
   }
 
-  const TooltipContent = React.forwardRef(function TooltipContent(
-    props,
-    ref: ForwardedRef<HTMLDivElement>
-  ) {
-    return (
-      <div
-        {...props}
-        ref={ref}
-        onClick={(e) => e.stopPropagation()}
-        onMouseDown={(e) => e.stopPropagation()}
-        onMouseUp={(e) => e.stopPropagation()}
-      >
-        {typeof data === 'string' ? <Markdown>{data}</Markdown> : data}
-      </div>
-    )
-  })
-
-  TooltipContent.displayName = 'TooltipContent'
-
   return (
     <MuiTooltip
+      arrow
       enterDelay={enterDelay}
       enterNextDelay={400}
       followCursor={followCursor}
       placement='top'
-      title={<TooltipContent />}
       classes={{
         tooltip: classes,
         arrow: 'tooltip-arrow',
         popper: extraPopperClass
       }}
-      arrow
+      title={
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+          onMouseUp={(e) => e.stopPropagation()}
+        >
+          {typeof data === 'string' ? <Markdown>{data}</Markdown> : data}
+        </div>
+      }
       // when "title" prop is jsx, but not string, the component can't automatically set aria-label
       // so we need to set it manually
       {...(typeof data === 'string' && { 'aria-label': data })}


### PR DESCRIPTION
## Problem

The v1 `Tooltip` defined its `TooltipContent` wrapper **inside** the render body and passed it to MUI as `title={<TooltipContent />}`. A component type created during render is a new type on every render, so React **unmounts + remounts** the tooltip content whenever the parent re-renders.

For a rich, scrollable tooltip body that's refreshed by background polling, that remount resets scroll position / local state on every poll. Concretely: the WekaApp Statistics events-timeline overlay (the marker popup with a scrollable event list + "Show all") repolls every ~20s, and its scroll jumped back to the top each time (WEKAPP-643258).

## Fix

MUI renders `title` as plain content — it injects no ref/props into it — so the `forwardRef` wrapper was unnecessary. Render the content in an inline `<div>` instead: a host element has a **stable type**, so React reconciles it in place and scroll position / local state inside the tooltip survive parent re-renders. Also drops the now-unused `React` default import (clears pre-existing lint).

No API change; behavior is identical except the content no longer remounts on re-render. The v2 `Tooltip` already passes `title={data}` directly and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)