### PR TITLE
fix(v2): capacity widget sizing + inventory hover/padding (WEKAPP-646094)

### DIFF
--- a/lib/v2/components/widgets/CapacityWidget/capacityWidget.module.scss
+++ b/lib/v2/components/widgets/CapacityWidget/capacityWidget.module.scss
@@ -332,7 +332,7 @@ $capsule-radius: 50px;
   width: 358px;
   max-width: 100%;
   height: 30px;
-  padding: 1px 4px 2px 8px;
+  padding: 1px 8px 2px 8px;
   background-color: var(--gray-200-800);
   border-radius: 0;
 }
@@ -355,7 +355,7 @@ $capsule-radius: 50px;
 }
 
 .provisionedSection .totalPill {
-  width: 240px;
+  width: 280px;
   margin-top: auto;
   align-self: flex-start;
 }
@@ -411,8 +411,13 @@ $capsule-radius: 50px;
     gap: 12px;
   }
 
+  .provisionedSection {
+    padding-left: 10px;
+    padding-right: 0;
+  }
+
   .provisionedSection .totalPill {
-    width: 154px;
+    width: 200px;
   }
 
   .provisionedSection .totalLabel {

--- a/lib/v2/components/widgets/InventoryCard/inventoryCard.module.scss
+++ b/lib/v2/components/widgets/InventoryCard/inventoryCard.module.scss
@@ -14,17 +14,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 0;
+  padding: 12px 8px;
   flex: 1;
-
-  &:first-child {
-    padding-top: 0;
-  }
 }
 
 @container (height <= 244px) {
   .inventoryItem {
-    padding: 6px 0;
+    padding: 6px 8px;
   }
 }
 
@@ -33,12 +29,13 @@
   border: none;
   background: transparent;
   width: 100%;
+  box-sizing: border-box;
   font: inherit;
   color: inherit;
   text-align: left;
 
   &:hover {
-    background-color: var(--hover-bg, rgb(255 255 255 / 5%));
+    background-color: var(--gray-50-920);
   }
 }
 


### PR DESCRIPTION
CapacityWidget: widen the Total Provisioned pill (240->280 on large, 154->200
on small) and, on small screens, trim the provisioned-section padding (left
20->10, right 8->0) so the total value fits its background.

InventoryCard: add horizontal padding so the row hover highlight no longer
touches the text, make the first row's hover cover the full row height (drop the
:first-child padding-top:0), and switch the row-hover color to the shared
--gray-50-920 token so it matches the dashboard tables.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
