### PR TITLE
feat(v2): add CompactPerformanceChart shared widget (WH-4240, WEKAPP-648328)

### DIFF
--- a/lib/v2/components/charts/chartTypes.ts
+++ b/lib/v2/components/charts/chartTypes.ts
@@ -1,5 +1,11 @@
 export type ChartDataPoint = Record<string, number | string | null | undefined>
 
+export interface TimeSeriesPoint {
+  time: string
+  timestamp?: number
+  value: number
+}
+
 export type TickValue = string | number
 
 export type DomainValue = number | string | ((value: number) => number)

--- a/lib/v2/components/charts/utils/dataUtils.test.ts
+++ b/lib/v2/components/charts/utils/dataUtils.test.ts
@@ -44,6 +44,16 @@ describe('interpolateValue', () => {
       SECOND_POINT.value
     )
   })
+
+  it('sorts by timestamp so unordered input still picks the correct neighbors', () => {
+    const unorderedSeries = [SECOND_POINT, FIRST_POINT]
+    const midpointTimestamp =
+      (FIRST_POINT.timestamp + SECOND_POINT.timestamp) / 2
+    const midpointValue = (FIRST_POINT.value + SECOND_POINT.value) / 2
+    expect(interpolateValue(unorderedSeries, midpointTimestamp)).toBe(
+      midpointValue
+    )
+  })
 })
 
 describe('generateZeroLineData', () => {

--- a/lib/v2/components/charts/utils/dataUtils.test.ts
+++ b/lib/v2/components/charts/utils/dataUtils.test.ts
@@ -1,0 +1,115 @@
+import type { TimeSeriesPoint } from '../chartTypes'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  createCommonTimelineData,
+  generateZeroLineData,
+  interpolateValue
+} from './dataUtils'
+
+const EMPTY_SERIES: { timestamp: number; value: number }[] = []
+const FIRST_POINT = { timestamp: 100, value: 10 }
+const SECOND_POINT = { timestamp: 200, value: 20 }
+const series = [FIRST_POINT, SECOND_POINT]
+
+describe('interpolateValue', () => {
+  it('returns 0 for an empty series', () => {
+    expect(interpolateValue(EMPTY_SERIES, FIRST_POINT.timestamp)).toBe(0)
+  })
+
+  it('returns the exact value at a matching timestamp', () => {
+    expect(interpolateValue(series, SECOND_POINT.timestamp)).toBe(
+      SECOND_POINT.value
+    )
+  })
+
+  it('linearly interpolates between the surrounding points', () => {
+    const midpointTimestamp =
+      (FIRST_POINT.timestamp + SECOND_POINT.timestamp) / 2
+    const midpointValue = (FIRST_POINT.value + SECOND_POINT.value) / 2
+    expect(interpolateValue(series, midpointTimestamp)).toBe(midpointValue)
+  })
+
+  it('clamps to the first value when the target is before the series', () => {
+    const beforeSeriesTimestamp = FIRST_POINT.timestamp - 1
+    expect(interpolateValue(series, beforeSeriesTimestamp)).toBe(
+      FIRST_POINT.value
+    )
+  })
+
+  it('clamps to the last value when the target is after the series', () => {
+    const afterSeriesTimestamp = SECOND_POINT.timestamp + 1
+    expect(interpolateValue(series, afterSeriesTimestamp)).toBe(
+      SECOND_POINT.value
+    )
+  })
+})
+
+describe('generateZeroLineData', () => {
+  it('produces a zero-value point for each timestamp', () => {
+    const timestamps = [FIRST_POINT.timestamp, SECOND_POINT.timestamp]
+    const result = generateZeroLineData(timestamps)
+
+    expect(result.every((point) => point.value === 0)).toBe(true)
+    expect(result.map((point) => point.timestamp)).toEqual(timestamps)
+  })
+})
+
+describe('createCommonTimelineData', () => {
+  it('passes series through unchanged when none carry a timestamp', () => {
+    const throughputRaw: TimeSeriesPoint[] = [
+      { time: 't1', value: 100 },
+      { time: 't2', value: 150 }
+    ]
+    const iopsRaw: TimeSeriesPoint[] = [
+      { time: 't1', value: 1000 },
+      { time: 't2', value: 1500 }
+    ]
+    const latencyRaw: TimeSeriesPoint[] = [
+      { time: 't1', value: 1 },
+      { time: 't2', value: 2 }
+    ]
+
+    const result = createCommonTimelineData(throughputRaw, iopsRaw, latencyRaw)
+
+    expect(result.throughputData).toBe(throughputRaw)
+    expect(result.iopsData).toBe(iopsRaw)
+    expect(result.latencyData).toBe(latencyRaw)
+  })
+
+  it('merges timestamped series onto their union of timestamps', () => {
+    const throughputRaw: TimeSeriesPoint[] = [
+      { time: 't1', timestamp: FIRST_POINT.timestamp, value: 10 },
+      { time: 't2', timestamp: SECOND_POINT.timestamp, value: 20 }
+    ]
+    const iopsRaw: TimeSeriesPoint[] = [
+      { time: 't1', timestamp: FIRST_POINT.timestamp, value: 1000 }
+    ]
+    const latencyRaw: TimeSeriesPoint[] = []
+
+    const result = createCommonTimelineData(throughputRaw, iopsRaw, latencyRaw)
+
+    expect(result.throughputData.map((point) => point.timestamp)).toEqual([
+      FIRST_POINT.timestamp,
+      SECOND_POINT.timestamp
+    ])
+    expect(result.iopsData.map((point) => point.value)).toEqual([
+      iopsRaw[0].value,
+      iopsRaw[0].value
+    ])
+    expect(result.latencyData.every((point) => point.value === 0)).toBe(true)
+    expect(result.latencyData).toHaveLength(throughputRaw.length)
+  })
+
+  it('fills a metric with no raw data of its own with a zero line', () => {
+    const throughputRaw: TimeSeriesPoint[] = [
+      { time: 't1', timestamp: FIRST_POINT.timestamp, value: FIRST_POINT.value }
+    ]
+    const result = createCommonTimelineData(throughputRaw, [], [])
+
+    expect(result.throughputData).toHaveLength(throughputRaw.length)
+    expect(result.iopsData).toHaveLength(throughputRaw.length)
+    expect(result.iopsData[0].value).toBe(0)
+  })
+})

--- a/lib/v2/components/charts/utils/dataUtils.test.ts
+++ b/lib/v2/components/charts/utils/dataUtils.test.ts
@@ -129,6 +129,19 @@ describe('createCommonTimelineData', () => {
     )
   })
 
+  it('zero-fills an untimestamped series that does not line up 1:1 with the timeline', () => {
+    const throughputRaw: TimeSeriesPoint[] = [
+      { time: 't1', timestamp: FIRST_POINT.timestamp, value: 10 },
+      { time: 't2', timestamp: SECOND_POINT.timestamp, value: 20 }
+    ]
+    const iopsRaw: TimeSeriesPoint[] = [{ time: 't1', value: 1000 }]
+
+    const result = createCommonTimelineData(throughputRaw, iopsRaw, [])
+
+    expect(result.iopsData).toHaveLength(throughputRaw.length)
+    expect(result.iopsData.every((point) => point.value === 0)).toBe(true)
+  })
+
   it('fills a metric with no raw data of its own with a zero line', () => {
     const throughputRaw: TimeSeriesPoint[] = [
       { time: 't1', timestamp: FIRST_POINT.timestamp, value: FIRST_POINT.value }

--- a/lib/v2/components/charts/utils/dataUtils.test.ts
+++ b/lib/v2/components/charts/utils/dataUtils.test.ts
@@ -102,6 +102,23 @@ describe('createCommonTimelineData', () => {
     expect(result.latencyData).toHaveLength(throughputRaw.length)
   })
 
+  it('keeps a series that has values but no timestamps while a sibling is timestamped', () => {
+    const throughputRaw: TimeSeriesPoint[] = [
+      { time: 't1', timestamp: FIRST_POINT.timestamp, value: 10 },
+      { time: 't2', timestamp: SECOND_POINT.timestamp, value: 20 }
+    ]
+    const iopsRaw: TimeSeriesPoint[] = [
+      { time: 't1', value: 1000 },
+      { time: 't2', value: 1500 }
+    ]
+
+    const result = createCommonTimelineData(throughputRaw, iopsRaw, [])
+
+    expect(result.iopsData.map((point) => point.value)).toEqual(
+      iopsRaw.map((point) => point.value)
+    )
+  })
+
   it('fills a metric with no raw data of its own with a zero line', () => {
     const throughputRaw: TimeSeriesPoint[] = [
       { time: 't1', timestamp: FIRST_POINT.timestamp, value: FIRST_POINT.value }

--- a/lib/v2/components/charts/utils/dataUtils.ts
+++ b/lib/v2/components/charts/utils/dataUtils.ts
@@ -11,7 +11,8 @@ interface TimestampedValue {
  * Value at `targetTimestamp` for a raw time series: an exact match when one
  * exists, otherwise linear interpolation between the nearest surrounding
  * points (or the nearest edge point when `targetTimestamp` falls outside the
- * series). Returns `0` for an empty series.
+ * series). Returns `0` for an empty series. Input order does not matter — the
+ * points are sorted by timestamp before the neighbors are picked.
  */
 export function interpolateValue(
   rawData: TimestampedValue[],
@@ -21,17 +22,21 @@ export function interpolateValue(
     return 0
   }
 
-  const exactMatch = rawData.find(
+  const sortedData = [...rawData].sort(
+    (first, second) => first.timestamp - second.timestamp
+  )
+
+  const exactMatch = sortedData.find(
     (point) => point.timestamp === targetTimestamp
   )
   if (exactMatch) {
     return exactMatch.value
   }
 
-  const beforePoints = rawData.filter(
+  const beforePoints = sortedData.filter(
     (point) => point.timestamp < targetTimestamp
   )
-  const afterPoints = rawData.filter(
+  const afterPoints = sortedData.filter(
     (point) => point.timestamp > targetTimestamp
   )
 

--- a/lib/v2/components/charts/utils/dataUtils.ts
+++ b/lib/v2/components/charts/utils/dataUtils.ts
@@ -1,0 +1,140 @@
+import type { TimeSeriesPoint } from '../chartTypes'
+
+import { formatTooltipTimestamp } from './xAxisFormatters'
+
+interface TimestampedValue {
+  timestamp: number
+  value: number
+}
+
+/**
+ * Value at `targetTimestamp` for a raw time series: an exact match when one
+ * exists, otherwise linear interpolation between the nearest surrounding
+ * points (or the nearest edge point when `targetTimestamp` falls outside the
+ * series). Returns `0` for an empty series.
+ */
+export function interpolateValue(
+  rawData: TimestampedValue[],
+  targetTimestamp: number
+): number {
+  if (rawData.length === 0) {
+    return 0
+  }
+
+  const exactMatch = rawData.find(
+    (point) => point.timestamp === targetTimestamp
+  )
+  if (exactMatch) {
+    return exactMatch.value
+  }
+
+  const beforePoints = rawData.filter(
+    (point) => point.timestamp < targetTimestamp
+  )
+  const afterPoints = rawData.filter(
+    (point) => point.timestamp > targetTimestamp
+  )
+
+  if (beforePoints.length === 0) {
+    return afterPoints.length > 0 ? afterPoints[0].value : 0
+  }
+  if (afterPoints.length === 0) {
+    return beforePoints[beforePoints.length - 1].value
+  }
+
+  const beforePoint = beforePoints[beforePoints.length - 1]
+  const afterPoint = afterPoints[0]
+  const timeDiff = afterPoint.timestamp - beforePoint.timestamp
+  const valueRange = afterPoint.value - beforePoint.value
+  const targetProgress = (targetTimestamp - beforePoint.timestamp) / timeDiff
+
+  return beforePoint.value + valueRange * targetProgress
+}
+
+/** Flat zero-value series at the given timestamps, for a metric with no raw data of its own. */
+export function generateZeroLineData(
+  timestamps: number[]
+): TimeSeriesPoint[] {
+  return timestamps.map((timestamp) => ({
+    timestamp,
+    time: formatTooltipTimestamp(timestamp),
+    value: 0
+  }))
+}
+
+const hasAnyTimestamp = (points: TimeSeriesPoint[]): boolean =>
+  points.some((point) => point.timestamp !== undefined)
+
+const toTimestampedValues = (
+  points: TimeSeriesPoint[]
+): TimestampedValue[] =>
+  points
+    .filter((point) => point.timestamp !== undefined)
+    .map((point) => ({ timestamp: point.timestamp as number, value: point.value }))
+
+/**
+ * Aligns the three metric series onto a single common timeline so the same
+ * `dataIndex` refers to the same instant in every series (required for the
+ * synced hover cursor + unified tooltip to read matching points).
+ *
+ * When none of the incoming points carry a `timestamp`, the series are
+ * assumed already positionally aligned (the common case for a single shared
+ * data source) and are returned unchanged. Otherwise every unique timestamp
+ * across the three series becomes a row, with missing values filled in by
+ * interpolation (or a flat zero line for a metric with no raw data at all).
+ */
+export function createCommonTimelineData(
+  throughputRaw: TimeSeriesPoint[],
+  iopsRaw: TimeSeriesPoint[],
+  latencyRaw: TimeSeriesPoint[]
+): {
+  throughputData: TimeSeriesPoint[]
+  iopsData: TimeSeriesPoint[]
+  latencyData: TimeSeriesPoint[]
+} {
+  const isTimestamped =
+    hasAnyTimestamp(throughputRaw) ||
+    hasAnyTimestamp(iopsRaw) ||
+    hasAnyTimestamp(latencyRaw)
+
+  if (!isTimestamped) {
+    return {
+      throughputData: throughputRaw,
+      iopsData: iopsRaw,
+      latencyData: latencyRaw
+    }
+  }
+
+  const allTimestamps = new Set<number>()
+  ;[throughputRaw, iopsRaw, latencyRaw].forEach((points) => {
+    points.forEach((point) => {
+      if (point.timestamp !== undefined) {
+        allTimestamps.add(point.timestamp)
+      }
+    })
+  })
+
+  const sortedTimestamps = Array.from(allTimestamps).sort(
+    (first, second) => first - second
+  )
+
+  const alignToTimeline = (
+    points: TimeSeriesPoint[]
+  ): TimeSeriesPoint[] => {
+    const timestampedValues = toTimestampedValues(points)
+    if (timestampedValues.length === 0) {
+      return generateZeroLineData(sortedTimestamps)
+    }
+    return sortedTimestamps.map((timestamp) => ({
+      timestamp,
+      time: formatTooltipTimestamp(timestamp),
+      value: interpolateValue(timestampedValues, timestamp)
+    }))
+  }
+
+  return {
+    throughputData: alignToTimeline(throughputRaw),
+    iopsData: alignToTimeline(iopsRaw),
+    latencyData: alignToTimeline(latencyRaw)
+  }
+}

--- a/lib/v2/components/charts/utils/dataUtils.ts
+++ b/lib/v2/components/charts/utils/dataUtils.ts
@@ -129,10 +129,13 @@ export function createCommonTimelineData(
 
     const timestampedValues = toTimestampedValues(points)
     if (timestampedValues.length === 0) {
+      if (points.length !== sortedTimestamps.length) {
+        return generateZeroLineData(sortedTimestamps)
+      }
       return sortedTimestamps.map((timestamp, index) => ({
         timestamp,
         time: formatTooltipTimestamp(timestamp),
-        value: points[index]?.value ?? 0
+        value: points[index].value
       }))
     }
 

--- a/lib/v2/components/charts/utils/dataUtils.ts
+++ b/lib/v2/components/charts/utils/dataUtils.ts
@@ -51,10 +51,8 @@ export function interpolateValue(
   return beforePoint.value + valueRange * targetProgress
 }
 
-/** Flat zero-value series at the given timestamps, for a metric with no raw data of its own. */
-export function generateZeroLineData(
-  timestamps: number[]
-): TimeSeriesPoint[] {
+/** Flat zero-value series at the given timestamps, for a series with no raw data of its own. */
+export function generateZeroLineData(timestamps: number[]): TimeSeriesPoint[] {
   return timestamps.map((timestamp) => ({
     timestamp,
     time: formatTooltipTimestamp(timestamp),
@@ -65,23 +63,24 @@ export function generateZeroLineData(
 const hasAnyTimestamp = (points: TimeSeriesPoint[]): boolean =>
   points.some((point) => point.timestamp !== undefined)
 
-const toTimestampedValues = (
-  points: TimeSeriesPoint[]
-): TimestampedValue[] =>
+const toTimestampedValues = (points: TimeSeriesPoint[]): TimestampedValue[] =>
   points
     .filter((point) => point.timestamp !== undefined)
-    .map((point) => ({ timestamp: point.timestamp as number, value: point.value }))
+    .map((point) => ({
+      timestamp: point.timestamp as number,
+      value: point.value
+    }))
 
 /**
- * Aligns the three metric series onto a single common timeline so the same
- * `dataIndex` refers to the same instant in every series (required for the
- * synced hover cursor + unified tooltip to read matching points).
+ * Aligns three raw series onto a single common timeline so the same array
+ * index refers to the same instant in every returned series, letting callers
+ * read matching points across all three by one shared index.
  *
  * When none of the incoming points carry a `timestamp`, the series are
  * assumed already positionally aligned (the common case for a single shared
  * data source) and are returned unchanged. Otherwise every unique timestamp
  * across the three series becomes a row, with missing values filled in by
- * interpolation (or a flat zero line for a metric with no raw data at all).
+ * interpolation (or a flat zero line for a series with no raw data at all).
  */
 export function createCommonTimelineData(
   throughputRaw: TimeSeriesPoint[],
@@ -118,13 +117,20 @@ export function createCommonTimelineData(
     (first, second) => first - second
   )
 
-  const alignToTimeline = (
-    points: TimeSeriesPoint[]
-  ): TimeSeriesPoint[] => {
-    const timestampedValues = toTimestampedValues(points)
-    if (timestampedValues.length === 0) {
+  const alignToTimeline = (points: TimeSeriesPoint[]): TimeSeriesPoint[] => {
+    if (points.length === 0) {
       return generateZeroLineData(sortedTimestamps)
     }
+
+    const timestampedValues = toTimestampedValues(points)
+    if (timestampedValues.length === 0) {
+      return sortedTimestamps.map((timestamp, index) => ({
+        timestamp,
+        time: formatTooltipTimestamp(timestamp),
+        value: points[index]?.value ?? 0
+      }))
+    }
+
     return sortedTimestamps.map((timestamp) => ({
       timestamp,
       time: formatTooltipTimestamp(timestamp),

--- a/lib/v2/components/index.ts
+++ b/lib/v2/components/index.ts
@@ -489,5 +489,11 @@ export type {
   ClusterProtectionProps
 } from './widgets/ClusterProtection'
 export { ClusterProtection } from './widgets/ClusterProtection'
+export type {
+  CompactPerformanceChartProps,
+  CompactPerformanceDataPoint,
+  CompactPerformanceMetricData
+} from './widgets/CompactPerformanceChart'
+export { CompactPerformanceChart } from './widgets/CompactPerformanceChart'
 export type { InventoryCardProps, InventoryItem } from './widgets/InventoryCard'
 export { InventoryCard } from './widgets/InventoryCard'

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.stories.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.stories.tsx
@@ -1,0 +1,97 @@
+import type { CompactPerformanceDataPoint } from './types'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { CompactPerformanceChart } from './CompactPerformanceChart'
+
+const meta: Meta<typeof CompactPerformanceChart> = {
+  title: 'v2/Widgets/CompactPerformanceChart',
+  component: CompactPerformanceChart,
+  tags: ['autodocs']
+}
+
+export default meta
+type Story = StoryObj<typeof CompactPerformanceChart>
+
+const containerStyle = {
+  width: '480px',
+  height: '260px'
+}
+
+const THROUGHPUT: CompactPerformanceDataPoint[] = [
+  { time: '10:00', value: 120 },
+  { time: '10:01', value: 150 },
+  { time: '10:02', value: 180 },
+  { time: '10:03', value: 140 },
+  { time: '10:04', value: 200 }
+]
+
+const IOPS: CompactPerformanceDataPoint[] = [
+  { time: '10:00', value: 1200 },
+  { time: '10:01', value: 1500 },
+  { time: '10:02', value: 1800 },
+  { time: '10:03', value: 1400 },
+  { time: '10:04', value: 2000 }
+]
+
+const LATENCY: CompactPerformanceDataPoint[] = [
+  { time: '10:00', value: 1.2 },
+  { time: '10:01', value: 1.4 },
+  { time: '10:02', value: 1.1 },
+  { time: '10:03', value: 1.6 },
+  { time: '10:04', value: 1.3 }
+]
+
+const formatThroughput = (value: number) => `${value.toFixed(1)} MB/s`
+const formatIops = (value: number) => `${value.toFixed(0)} ops`
+const formatLatency = (value: number) => `${value.toFixed(2)} ms`
+
+export const Default: Story = {
+  render: () => (
+    <div style={containerStyle}>
+      <CompactPerformanceChart
+        iops={{
+          data: IOPS,
+          formatValue: formatIops,
+          label: 'IOPS'
+        }}
+        latency={{
+          data: LATENCY,
+          formatValue: formatLatency,
+          label: 'Avg. Latency'
+        }}
+        throughput={{
+          data: THROUGHPUT,
+          formatValue: formatThroughput,
+          label: 'Throughput'
+        }}
+      />
+    </div>
+  )
+}
+
+export const Loading: Story = {
+  render: () => (
+    <div style={containerStyle}>
+      <CompactPerformanceChart
+        iops={{
+          data: [],
+          formatValue: formatIops,
+          isLoading: true,
+          label: 'IOPS'
+        }}
+        latency={{
+          data: [],
+          formatValue: formatLatency,
+          isLoading: true,
+          label: 'Avg. Latency'
+        }}
+        throughput={{
+          data: [],
+          formatValue: formatThroughput,
+          isLoading: true,
+          label: 'Throughput'
+        }}
+      />
+    </div>
+  )
+}

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
@@ -226,6 +226,31 @@ describe('CompactPerformanceChart', () => {
     expect(screen.queryByText(EMPTY_CONTENT)).not.toBeInTheDocument()
   })
 
+  it('does not swap a hovered chart to its loading skeleton mid-hover', () => {
+    const throughputLoadingTestId = `${CONTAINER_TEST_ID}-throughput-loading`
+    capturedOnMouseMove.length = 0
+    const props = buildProps()
+    const { rerender } = render(<CompactPerformanceChart {...props} />)
+
+    act(() => {
+      capturedOnMouseMove[0]({ activeTooltipIndex: 1, activeLabel: '10:01' })
+    })
+
+    rerender(
+      <CompactPerformanceChart
+        {...props}
+        throughput={{ ...props.throughput, isLoading: true }}
+      />
+    )
+    expect(
+      screen.queryByTestId(throughputLoadingTestId)
+    ).not.toBeInTheDocument()
+
+    fireEvent.mouseLeave(screen.getByTestId(CONTAINER_TEST_ID))
+
+    expect(screen.getByTestId(throughputLoadingTestId)).toBeInTheDocument()
+  })
+
   it('resumes live data immediately once the tooltip deactivates', () => {
     capturedOnMouseMove.length = 0
     const props = buildProps()

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { CompactPerformanceChart } from './CompactPerformanceChart'
@@ -7,27 +7,20 @@ type MouseMoveHandler = (state: {
   activeTooltipIndex?: number
   activeLabel?: string
 }) => void
-type MouseLeaveHandler = () => void
 
 const capturedOnMouseMove: MouseMoveHandler[] = []
-const capturedOnMouseLeave: MouseLeaveHandler[] = []
 
 vi.mock('recharts', () => ({
   Area: () => null,
   AreaChart: ({
     children,
-    onMouseMove,
-    onMouseLeave
+    onMouseMove
   }: {
     children?: unknown
     onMouseMove?: MouseMoveHandler
-    onMouseLeave?: MouseLeaveHandler
   }) => {
     if (onMouseMove) {
       capturedOnMouseMove.push(onMouseMove)
-    }
-    if (onMouseLeave) {
-      capturedOnMouseLeave.push(onMouseLeave)
     }
     return children ?? null
   },
@@ -37,6 +30,9 @@ vi.mock('recharts', () => ({
   XAxis: () => null,
   YAxis: () => null
 }))
+
+const CONTAINER_TEST_ID = 'compact-performance'
+const TOOLTIP_TEST_ID = 'compact-performance-tooltip'
 
 const buildProps = () => ({
   throughput: {
@@ -63,7 +59,7 @@ const buildProps = () => ({
     formatValue: (value: number) => `${value} ms`,
     label: 'Avg. Latency'
   },
-  dataTestId: 'compact-performance'
+  dataTestId: CONTAINER_TEST_ID
 })
 
 describe('CompactPerformanceChart', () => {
@@ -86,7 +82,7 @@ describe('CompactPerformanceChart', () => {
     render(<CompactPerformanceChart {...buildProps()} />)
 
     expect(
-      screen.queryByTestId('compact-performance-tooltip')
+      screen.queryByTestId(TOOLTIP_TEST_ID)
     ).not.toBeInTheDocument()
   })
 
@@ -99,7 +95,7 @@ describe('CompactPerformanceChart', () => {
     })
 
     expect(
-      screen.getByTestId('compact-performance-tooltip')
+      screen.getByTestId(TOOLTIP_TEST_ID)
     ).toBeInTheDocument()
     expect(screen.getByText('150 MB/s')).toBeInTheDocument()
     expect(screen.getByText('1500 ops')).toBeInTheDocument()
@@ -150,9 +146,26 @@ describe('CompactPerformanceChart', () => {
     expect(screen.queryByText('999 MB/s')).not.toBeInTheDocument()
   })
 
+  it('hides the unified tooltip once the pointer leaves the chart container', () => {
+    capturedOnMouseMove.length = 0
+    render(<CompactPerformanceChart {...buildProps()} />)
+
+    act(() => {
+      capturedOnMouseMove[0]({ activeTooltipIndex: 1, activeLabel: '10:01' })
+    })
+    expect(
+      screen.getByTestId(TOOLTIP_TEST_ID)
+    ).toBeInTheDocument()
+
+    fireEvent.mouseLeave(screen.getByTestId(CONTAINER_TEST_ID))
+
+    expect(
+      screen.queryByTestId(TOOLTIP_TEST_ID)
+    ).not.toBeInTheDocument()
+  })
+
   it('resumes live data immediately once the tooltip deactivates', () => {
     capturedOnMouseMove.length = 0
-    capturedOnMouseLeave.length = 0
     const props = buildProps()
     const { rerender } = render(<CompactPerformanceChart {...props} />)
 
@@ -169,9 +182,7 @@ describe('CompactPerformanceChart', () => {
     }
     rerender(<CompactPerformanceChart {...updatedProps} />)
 
-    act(() => {
-      capturedOnMouseLeave[0]()
-    })
+    fireEvent.mouseLeave(screen.getByTestId(CONTAINER_TEST_ID))
 
     expect(screen.getByText('999 MB/s')).toBeInTheDocument()
   })

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
@@ -1,6 +1,8 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+import { EMPTY_CONTENT } from '#consts'
+
 import { CompactPerformanceChart } from './CompactPerformanceChart'
 
 type MouseMoveHandler = (state: {
@@ -120,6 +122,25 @@ describe('CompactPerformanceChart', () => {
     expect(screen.getByText('150 MB/s')).toBeInTheDocument()
     expect(screen.getByText('1500 ops')).toBeInTheDocument()
     expect(screen.getByText('2 ms')).toBeInTheDocument()
+  })
+
+  it('shows a placeholder for a still-loading metric instead of a zero value', () => {
+    capturedOnMouseMove.length = 0
+    const props = buildProps()
+    render(
+      <CompactPerformanceChart
+        {...props}
+        iops={{ ...props.iops, data: [], isLoading: true }}
+      />
+    )
+
+    act(() => {
+      capturedOnMouseMove[0]({ activeTooltipIndex: 1, activeLabel: '10:01' })
+    })
+
+    expect(screen.getByText('150 MB/s')).toBeInTheDocument()
+    expect(screen.getByText(EMPTY_CONTENT)).toBeInTheDocument()
+    expect(screen.queryByText('0 ops')).not.toBeInTheDocument()
   })
 
   it('reflects a new data-prop update while the tooltip is inactive', () => {

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
@@ -9,18 +9,24 @@ type MouseMoveHandler = (state: {
 }) => void
 
 const capturedOnMouseMove: MouseMoveHandler[] = []
+const capturedSyncIds: string[] = []
 
 vi.mock('recharts', () => ({
   Area: () => null,
   AreaChart: ({
     children,
-    onMouseMove
+    onMouseMove,
+    syncId
   }: {
     children?: unknown
     onMouseMove?: MouseMoveHandler
+    syncId?: string
   }) => {
     if (onMouseMove) {
       capturedOnMouseMove.push(onMouseMove)
+    }
+    if (syncId) {
+      capturedSyncIds.push(syncId)
     }
     return children ?? null
   },
@@ -76,6 +82,20 @@ describe('CompactPerformanceChart', () => {
     expect(screen.getByText('Throughput')).toBeInTheDocument()
     expect(screen.getByText('IOPS')).toBeInTheDocument()
     expect(screen.getByText('Avg. Latency')).toBeInTheDocument()
+  })
+
+  it('syncs its own three charts together but not across separate instances', () => {
+    const CHARTS_PER_INSTANCE = 3
+    capturedSyncIds.length = 0
+    render(<CompactPerformanceChart {...buildProps()} />)
+    render(<CompactPerformanceChart {...buildProps()} />)
+
+    const firstInstance = capturedSyncIds.slice(0, CHARTS_PER_INSTANCE)
+    const secondInstance = capturedSyncIds.slice(CHARTS_PER_INSTANCE)
+
+    expect(new Set(firstInstance).size).toBe(1)
+    expect(new Set(secondInstance).size).toBe(1)
+    expect(firstInstance[0]).not.toBe(secondInstance[0])
   })
 
   it('does not render the unified tooltip before any chart is hovered', () => {

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
@@ -205,6 +205,27 @@ describe('CompactPerformanceChart', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('keeps a frozen metric value in the tooltip when it starts loading mid-hover', () => {
+    capturedOnMouseMove.length = 0
+    const props = buildProps()
+    const { rerender } = render(<CompactPerformanceChart {...props} />)
+
+    act(() => {
+      capturedOnMouseMove[0]({ activeTooltipIndex: 1, activeLabel: '10:01' })
+    })
+    expect(screen.getByText('1500 ops')).toBeInTheDocument()
+
+    rerender(
+      <CompactPerformanceChart
+        {...props}
+        iops={{ ...props.iops, data: [], isLoading: true }}
+      />
+    )
+
+    expect(screen.getByText('1500 ops')).toBeInTheDocument()
+    expect(screen.queryByText(EMPTY_CONTENT)).not.toBeInTheDocument()
+  })
+
   it('resumes live data immediately once the tooltip deactivates', () => {
     capturedOnMouseMove.length = 0
     const props = buildProps()

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.test.tsx
@@ -1,0 +1,178 @@
+import { act, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CompactPerformanceChart } from './CompactPerformanceChart'
+
+type MouseMoveHandler = (state: {
+  activeTooltipIndex?: number
+  activeLabel?: string
+}) => void
+type MouseLeaveHandler = () => void
+
+const capturedOnMouseMove: MouseMoveHandler[] = []
+const capturedOnMouseLeave: MouseLeaveHandler[] = []
+
+vi.mock('recharts', () => ({
+  Area: () => null,
+  AreaChart: ({
+    children,
+    onMouseMove,
+    onMouseLeave
+  }: {
+    children?: unknown
+    onMouseMove?: MouseMoveHandler
+    onMouseLeave?: MouseLeaveHandler
+  }) => {
+    if (onMouseMove) {
+      capturedOnMouseMove.push(onMouseMove)
+    }
+    if (onMouseLeave) {
+      capturedOnMouseLeave.push(onMouseLeave)
+    }
+    return children ?? null
+  },
+  ResponsiveContainer: ({ children }: { children?: unknown }) =>
+    children ?? null,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null
+}))
+
+const buildProps = () => ({
+  throughput: {
+    data: [
+      { time: '10:00', value: 100 },
+      { time: '10:01', value: 150 }
+    ],
+    formatValue: (value: number) => `${value} MB/s`,
+    label: 'Throughput'
+  },
+  iops: {
+    data: [
+      { time: '10:00', value: 1000 },
+      { time: '10:01', value: 1500 }
+    ],
+    formatValue: (value: number) => `${value} ops`,
+    label: 'IOPS'
+  },
+  latency: {
+    data: [
+      { time: '10:00', value: 1 },
+      { time: '10:01', value: 2 }
+    ],
+    formatValue: (value: number) => `${value} ms`,
+    label: 'Avg. Latency'
+  },
+  dataTestId: 'compact-performance'
+})
+
+describe('CompactPerformanceChart', () => {
+  it('renders all three charts with their labels', () => {
+    render(<CompactPerformanceChart {...buildProps()} />)
+
+    expect(
+      screen.getByTestId('compact-performance-throughput')
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('compact-performance-iops')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('compact-performance-latency')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Throughput')).toBeInTheDocument()
+    expect(screen.getByText('IOPS')).toBeInTheDocument()
+    expect(screen.getByText('Avg. Latency')).toBeInTheDocument()
+  })
+
+  it('does not render the unified tooltip before any chart is hovered', () => {
+    render(<CompactPerformanceChart {...buildProps()} />)
+
+    expect(
+      screen.queryByTestId('compact-performance-tooltip')
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the unified tooltip with all three values once a chart reports a hovered point', () => {
+    capturedOnMouseMove.length = 0
+    render(<CompactPerformanceChart {...buildProps()} />)
+
+    act(() => {
+      capturedOnMouseMove[0]({ activeTooltipIndex: 1, activeLabel: '10:01' })
+    })
+
+    expect(
+      screen.getByTestId('compact-performance-tooltip')
+    ).toBeInTheDocument()
+    expect(screen.getByText('150 MB/s')).toBeInTheDocument()
+    expect(screen.getByText('1500 ops')).toBeInTheDocument()
+    expect(screen.getByText('2 ms')).toBeInTheDocument()
+  })
+
+  it('reflects a new data-prop update while the tooltip is inactive', () => {
+    const props = buildProps()
+    const { rerender } = render(<CompactPerformanceChart {...props} />)
+
+    expect(screen.getByText('150 MB/s')).toBeInTheDocument()
+
+    rerender(
+      <CompactPerformanceChart
+        {...props}
+        throughput={{
+          ...props.throughput,
+          data: [...props.throughput.data, { time: '10:02', value: 999 }]
+        }}
+      />
+    )
+
+    expect(screen.getByText('999 MB/s')).toBeInTheDocument()
+  })
+
+  it('keeps the tooltip and charts on the pre-hover snapshot while active, ignoring a concurrent data-prop update', () => {
+    capturedOnMouseMove.length = 0
+    const props = buildProps()
+    const { rerender } = render(<CompactPerformanceChart {...props} />)
+
+    act(() => {
+      capturedOnMouseMove[0]({ activeTooltipIndex: 1, activeLabel: '10:01' })
+    })
+
+    expect(screen.getByText('150 MB/s')).toBeInTheDocument()
+
+    rerender(
+      <CompactPerformanceChart
+        {...props}
+        throughput={{
+          ...props.throughput,
+          data: [...props.throughput.data, { time: '10:02', value: 999 }]
+        }}
+      />
+    )
+
+    expect(screen.getByText('150 MB/s')).toBeInTheDocument()
+    expect(screen.queryByText('999 MB/s')).not.toBeInTheDocument()
+  })
+
+  it('resumes live data immediately once the tooltip deactivates', () => {
+    capturedOnMouseMove.length = 0
+    capturedOnMouseLeave.length = 0
+    const props = buildProps()
+    const { rerender } = render(<CompactPerformanceChart {...props} />)
+
+    act(() => {
+      capturedOnMouseMove[0]({ activeTooltipIndex: 1, activeLabel: '10:01' })
+    })
+
+    const updatedProps = {
+      ...props,
+      throughput: {
+        ...props.throughput,
+        data: [...props.throughput.data, { time: '10:02', value: 999 }]
+      }
+    }
+    rerender(<CompactPerformanceChart {...updatedProps} />)
+
+    act(() => {
+      capturedOnMouseLeave[0]()
+    })
+
+    expect(screen.getByText('999 MB/s')).toBeInTheDocument()
+  })
+})

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
@@ -1,0 +1,157 @@
+import type { CompactPerformanceChartProps, TooltipState } from './types'
+
+import { useMemo, useState } from 'react'
+
+import { EMPTY_STRING } from '#v2/utils/consts'
+
+import { createCommonTimelineData } from '../../charts/utils/dataUtils'
+import { MiniChartWrapper } from './MiniChartWrapper'
+import { UnifiedTooltip } from './UnifiedTooltip'
+
+import styles from './compactPerformanceChart.module.scss'
+
+const DEFAULT_THROUGHPUT_COLOR = 'var(--cyan-500)'
+const DEFAULT_IOPS_COLOR = 'var(--aqua-500)'
+const DEFAULT_LATENCY_COLOR = 'var(--orange-500)'
+
+const INITIAL_TOOLTIP_STATE: TooltipState = {
+  active: false,
+  label: EMPTY_STRING,
+  dataIndex: -1,
+  viewportX: 0,
+  viewportY: 0
+}
+
+const testId = (
+  dataTestId: string | undefined,
+  suffix: string
+): string | undefined => (dataTestId ? `${dataTestId}-${suffix}` : undefined)
+
+/**
+ * Three syncId-synced mini charts (throughput, IOPS, avg. latency) with a
+ * unified cross-chart hover tooltip. Prop-only: the caller supplies each
+ * metric's data, formatter and label; the component aligns the three series
+ * onto a common timeline internally so hovering one chart drives all three.
+ */
+export function CompactPerformanceChart({
+  throughput,
+  iops,
+  latency,
+  dataTestId
+}: Readonly<CompactPerformanceChartProps>) {
+  const [tooltipState, setTooltipState] = useState<TooltipState>(
+    INITIAL_TOOLTIP_STATE
+  )
+
+  const liveSeries = useMemo(
+    () => createCommonTimelineData(throughput.data, iops.data, latency.data),
+    [throughput.data, iops.data, latency.data]
+  )
+
+  /**
+   * Freeze the aligned series while the tooltip is active.
+   *
+   * Recharts re-selects its active point from an unscaled, stored `chartX`
+   * whenever it re-renders with a new `data` array and no accompanying mouse
+   * event — under a page transform/scale this makes the cursor hop to a
+   * neighboring point on every poll even though the mouse hasn't moved. Since
+   * the live-polling `data` props change every few seconds, holding the last
+   * pre-hover snapshot for as long as the tooltip stays active (instead of
+   * feeding recharts the incoming data) keeps the inspected point stable;
+   * resuming live data is instant once the tooltip deactivates.
+   *
+   * This mirrors React's "adjusting state during render" pattern (comparing
+   * against the previous render's value directly in the render body) rather
+   * than a `useEffect`, so the frozen snapshot is committed in the very same
+   * render that activates the tooltip — a later poll update can never sneak
+   * in between activation and the freeze taking effect.
+   */
+  const [wasTooltipActive, setWasTooltipActive] = useState(
+    tooltipState.active
+  )
+  const [frozenSeries, setFrozenSeries] = useState(liveSeries)
+  if (tooltipState.active !== wasTooltipActive) {
+    setWasTooltipActive(tooltipState.active)
+    if (tooltipState.active) {
+      setFrozenSeries(liveSeries)
+    }
+  }
+
+  const { throughputData, iopsData, latencyData } = tooltipState.active
+    ? frozenSeries
+    : liveSeries
+
+  const throughputColor = throughput.color ?? DEFAULT_THROUGHPUT_COLOR
+  const iopsColor = iops.color ?? DEFAULT_IOPS_COLOR
+  const latencyColor = latency.color ?? DEFAULT_LATENCY_COLOR
+
+  return (
+    <div
+      className={styles.chartsContainer}
+      data-testid={dataTestId}
+    >
+      <MiniChartWrapper
+        color={throughputColor}
+        data={throughputData}
+        dataTestId={testId(dataTestId, 'throughput')}
+        formatValue={throughput.formatValue}
+        hasValidData={throughput.hasValidData}
+        isHovered={tooltipState.active}
+        isLoading={throughput.isLoading}
+        label={throughput.label}
+        onTooltipChange={setTooltipState}
+      />
+      <MiniChartWrapper
+        color={iopsColor}
+        data={iopsData}
+        dataTestId={testId(dataTestId, 'iops')}
+        formatValue={iops.formatValue}
+        hasValidData={iops.hasValidData}
+        isHovered={tooltipState.active}
+        isLoading={iops.isLoading}
+        label={iops.label}
+        onTooltipChange={setTooltipState}
+      />
+      <MiniChartWrapper
+        color={latencyColor}
+        data={latencyData}
+        dataTestId={testId(dataTestId, 'latency')}
+        formatValue={latency.formatValue}
+        hasValidData={latency.hasValidData}
+        isHovered={tooltipState.active}
+        isLoading={latency.isLoading}
+        label={latency.label}
+        onTooltipChange={setTooltipState}
+      />
+      {tooltipState.active ? (
+        <UnifiedTooltip
+          dataIndex={tooltipState.dataIndex}
+          dataTestId={testId(dataTestId, 'tooltip')}
+          label={tooltipState.label}
+          viewportX={tooltipState.viewportX}
+          viewportY={tooltipState.viewportY}
+          metrics={[
+            {
+              data: throughputData,
+              label: throughput.label,
+              color: throughputColor,
+              formatValue: throughput.formatValue
+            },
+            {
+              data: iopsData,
+              label: iops.label,
+              color: iopsColor,
+              formatValue: iops.formatValue
+            },
+            {
+              data: latencyData,
+              label: latency.label,
+              color: latencyColor,
+              formatValue: latency.formatValue
+            }
+          ]}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
@@ -1,5 +1,6 @@
 import type {
   CompactPerformanceChartProps,
+  CompactPerformanceDataPoint,
   CompactPerformanceMetricData,
   TooltipState
 } from './types'
@@ -34,6 +35,23 @@ const testId = (
 const hasRealData = (metric: CompactPerformanceMetricData): boolean =>
   !metric.isLoading && metric.hasValidData !== false && metric.data.length > 0
 
+interface MetricRenderState {
+  data: CompactPerformanceDataPoint[]
+  isLoading: boolean
+  hasValidData: boolean
+  hasData: boolean
+}
+
+const toRenderState = (
+  metric: CompactPerformanceMetricData,
+  data: CompactPerformanceDataPoint[]
+): MetricRenderState => ({
+  data,
+  isLoading: metric.isLoading ?? false,
+  hasValidData: metric.hasValidData !== false,
+  hasData: hasRealData(metric)
+})
+
 /**
  * Three syncId-synced mini charts (throughput, IOPS, avg. latency) with a
  * unified cross-chart hover tooltip. Prop-only: the caller supplies each
@@ -52,47 +70,33 @@ export function CompactPerformanceChart({
 
   const syncId = useId()
 
-  const throughputHasData = hasRealData(throughput)
-  const iopsHasData = hasRealData(iops)
-  const latencyHasData = hasRealData(latency)
-
-  const liveSnapshot = useMemo(
-    () => ({
-      series: createCommonTimelineData(
-        throughput.data,
-        iops.data,
-        latency.data
-      ),
-      hasData: {
-        throughput: throughputHasData,
-        iops: iopsHasData,
-        latency: latencyHasData
-      }
-    }),
-    [
+  const liveSnapshot = useMemo(() => {
+    const { throughputData, iopsData, latencyData } = createCommonTimelineData(
       throughput.data,
       iops.data,
-      latency.data,
-      throughputHasData,
-      iopsHasData,
-      latencyHasData
-    ]
-  )
+      latency.data
+    )
+    return {
+      throughput: toRenderState(throughput, throughputData),
+      iops: toRenderState(iops, iopsData),
+      latency: toRenderState(latency, latencyData)
+    }
+  }, [throughput, iops, latency])
 
   /**
-   * Freeze the aligned series and each metric's data-availability while the
-   * tooltip is active.
+   * Freeze the whole per-metric render state (aligned series, loading and
+   * validity flags, and data-availability) while the tooltip is active.
    *
    * Recharts re-selects its active point from an unscaled, stored `chartX`
    * whenever it re-renders with a new `data` array and no accompanying mouse
    * event — under a page transform/scale this makes the cursor hop to a
    * neighboring point on every poll even though the mouse hasn't moved. Since
-   * the live-polling `data` props change every few seconds, holding the last
-   * pre-hover snapshot for as long as the tooltip stays active (instead of
-   * feeding recharts the incoming data) keeps the inspected point stable;
-   * resuming live data is instant once the tooltip deactivates. Freezing
-   * `hasData` alongside the series keeps the tooltip from flipping a value to
-   * or from its placeholder mid-hover when a poll changes a metric's state.
+   * the live-polling props change every few seconds, holding the last pre-hover
+   * snapshot for as long as the tooltip stays active (instead of feeding
+   * recharts the incoming values) keeps the inspected point stable; resuming
+   * live data is instant once the tooltip deactivates. Freezing the flags with
+   * the series keeps a mid-hover poll from swapping a chart for a skeleton or
+   * flipping a tooltip value to or from its placeholder while it is inspected.
    *
    * This mirrors React's "adjusting state during render" pattern (comparing
    * against the previous render's value directly in the render body) rather
@@ -111,8 +115,7 @@ export function CompactPerformanceChart({
     }
   }
 
-  const activeSnapshot = tooltipState.active ? frozenSnapshot : liveSnapshot
-  const { throughputData, iopsData, latencyData } = activeSnapshot.series
+  const snapshot = tooltipState.active ? frozenSnapshot : liveSnapshot
 
   const throughputColor = throughput.color ?? DEFAULT_THROUGHPUT_COLOR
   const iopsColor = iops.color ?? DEFAULT_IOPS_COLOR
@@ -131,39 +134,39 @@ export function CompactPerformanceChart({
     >
       <MiniChartWrapper
         color={throughputColor}
-        data={throughputData}
+        data={snapshot.throughput.data}
         dataTestId={testId(dataTestId, 'throughput')}
         formatValue={throughput.formatValue}
-        hasData={throughputHasData}
-        hasValidData={throughput.hasValidData}
+        hasData={snapshot.throughput.hasData}
+        hasValidData={snapshot.throughput.hasValidData}
         isHovered={tooltipState.active}
-        isLoading={throughput.isLoading}
+        isLoading={snapshot.throughput.isLoading}
         label={throughput.label}
         onTooltipChange={setTooltipState}
         syncId={syncId}
       />
       <MiniChartWrapper
         color={iopsColor}
-        data={iopsData}
+        data={snapshot.iops.data}
         dataTestId={testId(dataTestId, 'iops')}
         formatValue={iops.formatValue}
-        hasData={iopsHasData}
-        hasValidData={iops.hasValidData}
+        hasData={snapshot.iops.hasData}
+        hasValidData={snapshot.iops.hasValidData}
         isHovered={tooltipState.active}
-        isLoading={iops.isLoading}
+        isLoading={snapshot.iops.isLoading}
         label={iops.label}
         onTooltipChange={setTooltipState}
         syncId={syncId}
       />
       <MiniChartWrapper
         color={latencyColor}
-        data={latencyData}
+        data={snapshot.latency.data}
         dataTestId={testId(dataTestId, 'latency')}
         formatValue={latency.formatValue}
-        hasData={latencyHasData}
-        hasValidData={latency.hasValidData}
+        hasData={snapshot.latency.hasData}
+        hasValidData={snapshot.latency.hasValidData}
         isHovered={tooltipState.active}
-        isLoading={latency.isLoading}
+        isLoading={snapshot.latency.isLoading}
         label={latency.label}
         onTooltipChange={setTooltipState}
         syncId={syncId}
@@ -177,25 +180,25 @@ export function CompactPerformanceChart({
           viewportY={tooltipState.viewportY}
           metrics={[
             {
-              data: throughputData,
+              data: snapshot.throughput.data,
               label: throughput.label,
               color: throughputColor,
               formatValue: throughput.formatValue,
-              hasData: activeSnapshot.hasData.throughput
+              hasData: snapshot.throughput.hasData
             },
             {
-              data: iopsData,
+              data: snapshot.iops.data,
               label: iops.label,
               color: iopsColor,
               formatValue: iops.formatValue,
-              hasData: activeSnapshot.hasData.iops
+              hasData: snapshot.iops.hasData
             },
             {
-              data: latencyData,
+              data: snapshot.latency.data,
               label: latency.label,
               color: latencyColor,
               formatValue: latency.formatValue,
-              hasData: activeSnapshot.hasData.latency
+              hasData: snapshot.latency.hasData
             }
           ]}
         />

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
@@ -31,6 +31,9 @@ const testId = (
   suffix: string
 ): string | undefined => (dataTestId ? `${dataTestId}-${suffix}` : undefined)
 
+const hasRealData = (metric: CompactPerformanceMetricData): boolean =>
+  !metric.isLoading && metric.hasValidData !== false && metric.data.length > 0
+
 /**
  * Three syncId-synced mini charts (throughput, IOPS, avg. latency) with a
  * unified cross-chart hover tooltip. Prop-only: the caller supplies each
@@ -49,13 +52,36 @@ export function CompactPerformanceChart({
 
   const syncId = useId()
 
-  const liveSeries = useMemo(
-    () => createCommonTimelineData(throughput.data, iops.data, latency.data),
-    [throughput.data, iops.data, latency.data]
+  const throughputHasData = hasRealData(throughput)
+  const iopsHasData = hasRealData(iops)
+  const latencyHasData = hasRealData(latency)
+
+  const liveSnapshot = useMemo(
+    () => ({
+      series: createCommonTimelineData(
+        throughput.data,
+        iops.data,
+        latency.data
+      ),
+      hasData: {
+        throughput: throughputHasData,
+        iops: iopsHasData,
+        latency: latencyHasData
+      }
+    }),
+    [
+      throughput.data,
+      iops.data,
+      latency.data,
+      throughputHasData,
+      iopsHasData,
+      latencyHasData
+    ]
   )
 
   /**
-   * Freeze the aligned series while the tooltip is active.
+   * Freeze the aligned series and each metric's data-availability while the
+   * tooltip is active.
    *
    * Recharts re-selects its active point from an unscaled, stored `chartX`
    * whenever it re-renders with a new `data` array and no accompanying mouse
@@ -64,7 +90,9 @@ export function CompactPerformanceChart({
    * the live-polling `data` props change every few seconds, holding the last
    * pre-hover snapshot for as long as the tooltip stays active (instead of
    * feeding recharts the incoming data) keeps the inspected point stable;
-   * resuming live data is instant once the tooltip deactivates.
+   * resuming live data is instant once the tooltip deactivates. Freezing
+   * `hasData` alongside the series keeps the tooltip from flipping a value to
+   * or from its placeholder mid-hover when a poll changes a metric's state.
    *
    * This mirrors React's "adjusting state during render" pattern (comparing
    * against the previous render's value directly in the render body) rather
@@ -75,24 +103,20 @@ export function CompactPerformanceChart({
   const [wasTooltipActive, setWasTooltipActive] = useState(
     tooltipState.active
   )
-  const [frozenSeries, setFrozenSeries] = useState(liveSeries)
+  const [frozenSnapshot, setFrozenSnapshot] = useState(liveSnapshot)
   if (tooltipState.active !== wasTooltipActive) {
     setWasTooltipActive(tooltipState.active)
     if (tooltipState.active) {
-      setFrozenSeries(liveSeries)
+      setFrozenSnapshot(liveSnapshot)
     }
   }
 
-  const { throughputData, iopsData, latencyData } = tooltipState.active
-    ? frozenSeries
-    : liveSeries
+  const activeSnapshot = tooltipState.active ? frozenSnapshot : liveSnapshot
+  const { throughputData, iopsData, latencyData } = activeSnapshot.series
 
   const throughputColor = throughput.color ?? DEFAULT_THROUGHPUT_COLOR
   const iopsColor = iops.color ?? DEFAULT_IOPS_COLOR
   const latencyColor = latency.color ?? DEFAULT_LATENCY_COLOR
-
-  const hasRealData = (metric: CompactPerformanceMetricData): boolean =>
-    !metric.isLoading && metric.hasValidData !== false && metric.data.length > 0
 
   const handleMouseLeave = useCallback(
     () => setTooltipState(INITIAL_TOOLTIP_STATE),
@@ -110,6 +134,7 @@ export function CompactPerformanceChart({
         data={throughputData}
         dataTestId={testId(dataTestId, 'throughput')}
         formatValue={throughput.formatValue}
+        hasData={throughputHasData}
         hasValidData={throughput.hasValidData}
         isHovered={tooltipState.active}
         isLoading={throughput.isLoading}
@@ -122,6 +147,7 @@ export function CompactPerformanceChart({
         data={iopsData}
         dataTestId={testId(dataTestId, 'iops')}
         formatValue={iops.formatValue}
+        hasData={iopsHasData}
         hasValidData={iops.hasValidData}
         isHovered={tooltipState.active}
         isLoading={iops.isLoading}
@@ -134,6 +160,7 @@ export function CompactPerformanceChart({
         data={latencyData}
         dataTestId={testId(dataTestId, 'latency')}
         formatValue={latency.formatValue}
+        hasData={latencyHasData}
         hasValidData={latency.hasValidData}
         isHovered={tooltipState.active}
         isLoading={latency.isLoading}
@@ -154,21 +181,21 @@ export function CompactPerformanceChart({
               label: throughput.label,
               color: throughputColor,
               formatValue: throughput.formatValue,
-              hasData: hasRealData(throughput)
+              hasData: activeSnapshot.hasData.throughput
             },
             {
               data: iopsData,
               label: iops.label,
               color: iopsColor,
               formatValue: iops.formatValue,
-              hasData: hasRealData(iops)
+              hasData: activeSnapshot.hasData.iops
             },
             {
               data: latencyData,
               label: latency.label,
               color: latencyColor,
               formatValue: latency.formatValue,
-              hasData: hasRealData(latency)
+              hasData: activeSnapshot.hasData.latency
             }
           ]}
         />

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
@@ -1,6 +1,6 @@
 import type { CompactPerformanceChartProps, TooltipState } from './types'
 
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { EMPTY_STRING } from '#v2/utils/consts'
 
@@ -85,10 +85,16 @@ export function CompactPerformanceChart({
   const iopsColor = iops.color ?? DEFAULT_IOPS_COLOR
   const latencyColor = latency.color ?? DEFAULT_LATENCY_COLOR
 
+  const handleMouseLeave = useCallback(
+    () => setTooltipState(INITIAL_TOOLTIP_STATE),
+    []
+  )
+
   return (
     <div
       className={styles.chartsContainer}
       data-testid={dataTestId}
+      onMouseLeave={handleMouseLeave}
     >
       <MiniChartWrapper
         color={throughputColor}

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
@@ -1,4 +1,8 @@
-import type { CompactPerformanceChartProps, TooltipState } from './types'
+import type {
+  CompactPerformanceChartProps,
+  CompactPerformanceMetricData,
+  TooltipState
+} from './types'
 
 import { useCallback, useId, useMemo, useState } from 'react'
 
@@ -87,6 +91,9 @@ export function CompactPerformanceChart({
   const iopsColor = iops.color ?? DEFAULT_IOPS_COLOR
   const latencyColor = latency.color ?? DEFAULT_LATENCY_COLOR
 
+  const hasRealData = (metric: CompactPerformanceMetricData): boolean =>
+    !metric.isLoading && metric.hasValidData !== false && metric.data.length > 0
+
   const handleMouseLeave = useCallback(
     () => setTooltipState(INITIAL_TOOLTIP_STATE),
     []
@@ -146,19 +153,22 @@ export function CompactPerformanceChart({
               data: throughputData,
               label: throughput.label,
               color: throughputColor,
-              formatValue: throughput.formatValue
+              formatValue: throughput.formatValue,
+              hasData: hasRealData(throughput)
             },
             {
               data: iopsData,
               label: iops.label,
               color: iopsColor,
-              formatValue: iops.formatValue
+              formatValue: iops.formatValue,
+              hasData: hasRealData(iops)
             },
             {
               data: latencyData,
               label: latency.label,
               color: latencyColor,
-              formatValue: latency.formatValue
+              formatValue: latency.formatValue,
+              hasData: hasRealData(latency)
             }
           ]}
         />

--- a/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/CompactPerformanceChart.tsx
@@ -1,6 +1,6 @@
 import type { CompactPerformanceChartProps, TooltipState } from './types'
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useId, useMemo, useState } from 'react'
 
 import { EMPTY_STRING } from '#v2/utils/consts'
 
@@ -42,6 +42,8 @@ export function CompactPerformanceChart({
   const [tooltipState, setTooltipState] = useState<TooltipState>(
     INITIAL_TOOLTIP_STATE
   )
+
+  const syncId = useId()
 
   const liveSeries = useMemo(
     () => createCommonTimelineData(throughput.data, iops.data, latency.data),
@@ -106,6 +108,7 @@ export function CompactPerformanceChart({
         isLoading={throughput.isLoading}
         label={throughput.label}
         onTooltipChange={setTooltipState}
+        syncId={syncId}
       />
       <MiniChartWrapper
         color={iopsColor}
@@ -117,6 +120,7 @@ export function CompactPerformanceChart({
         isLoading={iops.isLoading}
         label={iops.label}
         onTooltipChange={setTooltipState}
+        syncId={syncId}
       />
       <MiniChartWrapper
         color={latencyColor}
@@ -128,6 +132,7 @@ export function CompactPerformanceChart({
         isLoading={latency.isLoading}
         label={latency.label}
         onTooltipChange={setTooltipState}
+        syncId={syncId}
       />
       {tooltipState.active ? (
         <UnifiedTooltip

--- a/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.test.tsx
@@ -41,13 +41,14 @@ const DATA: CompactPerformanceDataPoint[] = [
   { time: '10:01', value: 250 }
 ]
 
-const renderWrapper = (onTooltipChange = vi.fn()) => {
+const renderWrapper = (onTooltipChange = vi.fn(), hasData = true) => {
   render(
     <MiniChartWrapper
       color='var(--cyan-500)'
       data={DATA}
       dataTestId='throughput-chart'
       formatValue={(value) => `${value} MB/s`}
+      hasData={hasData}
       isHovered={false}
       label='Throughput'
       onTooltipChange={onTooltipChange}
@@ -56,6 +57,8 @@ const renderWrapper = (onTooltipChange = vi.fn()) => {
   )
   return onTooltipChange
 }
+
+const LAST_VALUE_BADGE = '250 MB/s'
 
 describe('MiniChartWrapper', () => {
   it('renders the label and forwards the dataTestId', () => {
@@ -112,5 +115,17 @@ describe('MiniChartWrapper', () => {
     capturedHandlers.onMouseMove?.({})
 
     expect(onTooltipChange).not.toHaveBeenCalled()
+  })
+
+  it('shows the last-value badge when the metric has data', () => {
+    renderWrapper()
+
+    expect(screen.getByText(LAST_VALUE_BADGE)).toBeInTheDocument()
+  })
+
+  it('hides the last-value badge when the metric has no data', () => {
+    renderWrapper(vi.fn(), false)
+
+    expect(screen.queryByText(LAST_VALUE_BADGE)).not.toBeInTheDocument()
   })
 })

--- a/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.test.tsx
@@ -1,0 +1,133 @@
+import type { CompactPerformanceDataPoint, TooltipState } from './types'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EMPTY_STRING } from '#consts'
+
+import { MiniChartWrapper } from './MiniChartWrapper'
+
+type CapturedRechartsHandlers = {
+  onMouseMove?: (
+    state: { activeTooltipIndex?: number; activeLabel?: string },
+    event?: { clientX: number; clientY: number }
+  ) => void
+  onMouseLeave?: () => void
+}
+
+const capturedHandlers: CapturedRechartsHandlers = {}
+
+vi.mock('recharts', () => ({
+  Area: () => null,
+  AreaChart: ({
+    children,
+    onMouseMove,
+    onMouseLeave
+  }: {
+    children?: unknown
+    onMouseMove?: CapturedRechartsHandlers['onMouseMove']
+    onMouseLeave?: CapturedRechartsHandlers['onMouseLeave']
+  }) => {
+    capturedHandlers.onMouseMove = onMouseMove
+    capturedHandlers.onMouseLeave = onMouseLeave
+
+    return children ?? null
+  },
+  ResponsiveContainer: ({ children }: { children?: unknown }) =>
+    children ?? null,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null
+}))
+
+const DATA: CompactPerformanceDataPoint[] = [
+  { time: '10:00', value: 100 },
+  { time: '10:01', value: 250 }
+]
+
+const renderWrapper = (onTooltipChange = vi.fn()) => {
+  render(
+    <MiniChartWrapper
+      color='var(--cyan-500)'
+      data={DATA}
+      dataTestId='throughput-chart'
+      formatValue={(value) => `${value} MB/s`}
+      isHovered={false}
+      label='Throughput'
+      onTooltipChange={onTooltipChange}
+    />
+  )
+  return onTooltipChange
+}
+
+describe('MiniChartWrapper', () => {
+  it('renders the label and forwards the dataTestId', () => {
+    renderWrapper()
+
+    expect(screen.getByTestId('throughput-chart-label')).toBeInTheDocument()
+    expect(screen.getByText('Throughput')).toBeInTheDocument()
+  })
+
+  it('preserves the prior position when recharts reports a synced hover with no event', () => {
+    const onTooltipChange = renderWrapper()
+
+    capturedHandlers.onMouseMove?.({ activeTooltipIndex: 1, activeLabel: '10:01' })
+
+    expect(onTooltipChange).toHaveBeenCalledTimes(1)
+    const updater = onTooltipChange.mock.calls[0][0] as (
+      prev: TooltipState
+    ) => TooltipState
+    const prevState: TooltipState = {
+      active: false,
+      label: EMPTY_STRING,
+      dataIndex: -1,
+      viewportX: 42,
+      viewportY: 24
+    }
+    expect(updater(prevState)).toEqual({
+      ...prevState,
+      active: true,
+      label: '10:01',
+      dataIndex: 1
+    })
+  })
+
+  it('captures the viewport mouse coordinates when recharts reports a hovered point with an event', () => {
+    const onTooltipChange = renderWrapper()
+
+    capturedHandlers.onMouseMove?.(
+      { activeTooltipIndex: 1, activeLabel: '10:01' },
+      { clientX: 321, clientY: 654 }
+    )
+
+    expect(onTooltipChange).toHaveBeenCalledWith({
+      active: true,
+      label: '10:01',
+      dataIndex: 1,
+      viewportX: 321,
+      viewportY: 654
+    })
+  })
+
+  it('ignores a hover event with no active point', () => {
+    const onTooltipChange = renderWrapper()
+
+    capturedHandlers.onMouseMove?.({})
+
+    expect(onTooltipChange).not.toHaveBeenCalled()
+  })
+
+  it('resets the tooltip state on mouse leave', () => {
+    const onTooltipChange = renderWrapper()
+
+    capturedHandlers.onMouseLeave?.()
+
+    expect(onTooltipChange).toHaveBeenCalledWith({
+      active: false,
+      label: EMPTY_STRING,
+      dataIndex: -1,
+      viewportX: 0,
+      viewportY: 0
+    })
+  })
+})

--- a/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.test.tsx
@@ -51,6 +51,7 @@ const renderWrapper = (onTooltipChange = vi.fn()) => {
       isHovered={false}
       label='Throughput'
       onTooltipChange={onTooltipChange}
+      syncId='test-sync-id'
     />
   )
   return onTooltipChange

--- a/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.test.tsx
@@ -12,7 +12,6 @@ type CapturedRechartsHandlers = {
     state: { activeTooltipIndex?: number; activeLabel?: string },
     event?: { clientX: number; clientY: number }
   ) => void
-  onMouseLeave?: () => void
 }
 
 const capturedHandlers: CapturedRechartsHandlers = {}
@@ -21,15 +20,12 @@ vi.mock('recharts', () => ({
   Area: () => null,
   AreaChart: ({
     children,
-    onMouseMove,
-    onMouseLeave
+    onMouseMove
   }: {
     children?: unknown
     onMouseMove?: CapturedRechartsHandlers['onMouseMove']
-    onMouseLeave?: CapturedRechartsHandlers['onMouseLeave']
   }) => {
     capturedHandlers.onMouseMove = onMouseMove
-    capturedHandlers.onMouseLeave = onMouseLeave
 
     return children ?? null
   },
@@ -115,19 +111,5 @@ describe('MiniChartWrapper', () => {
     capturedHandlers.onMouseMove?.({})
 
     expect(onTooltipChange).not.toHaveBeenCalled()
-  })
-
-  it('resets the tooltip state on mouse leave', () => {
-    const onTooltipChange = renderWrapper()
-
-    capturedHandlers.onMouseLeave?.()
-
-    expect(onTooltipChange).toHaveBeenCalledWith({
-      active: false,
-      label: EMPTY_STRING,
-      dataIndex: -1,
-      viewportX: 0,
-      viewportY: 0
-    })
   })
 })

--- a/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.tsx
@@ -19,6 +19,7 @@ interface MiniChartWrapperProps {
   syncId: string
   isLoading?: boolean
   hasValidData?: boolean
+  hasData?: boolean
   isHovered: boolean
   onTooltipChange: Dispatch<SetStateAction<TooltipState>>
   dataTestId?: string
@@ -45,6 +46,7 @@ export function MiniChartWrapper({
   syncId,
   isLoading = false,
   hasValidData = true,
+  hasData = true,
   isHovered,
   onTooltipChange,
   dataTestId
@@ -104,7 +106,7 @@ export function MiniChartWrapper({
         fill
         formatValue={formatValue}
         hasValidData={hasValidData}
-        hideLastValue={isHovered}
+        hideLastValue={isHovered || !hasData}
         isLoading={isLoading}
         onMouseMove={handleMouseMove}
         syncId={syncId}

--- a/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.tsx
@@ -1,0 +1,125 @@
+import type {
+  CompactPerformanceDataPoint,
+  RechartsMouseState,
+  TooltipState
+} from './types'
+import type { Dispatch, MouseEvent, SetStateAction } from 'react'
+
+import { useCallback } from 'react'
+
+import { EMPTY_STRING } from '#v2/utils/consts'
+
+import { MiniChart } from '../../charts/MiniChart'
+
+import styles from './compactPerformanceChart.module.scss'
+
+interface MiniChartWrapperProps {
+  label: string
+  data: CompactPerformanceDataPoint[]
+  color: string
+  formatValue: (value: number) => string
+  isLoading?: boolean
+  hasValidData?: boolean
+  isHovered: boolean
+  onTooltipChange: Dispatch<SetStateAction<TooltipState>>
+  dataTestId?: string
+}
+
+const SYNC_ID = 'compact-performance-chart'
+
+const INACTIVE_TOOLTIP_STATE: TooltipState = {
+  active: false,
+  label: EMPTY_STRING,
+  dataIndex: -1,
+  viewportX: 0,
+  viewportY: 0
+}
+
+/**
+ * Wraps the shared `MiniChart` with the cross-chart hover coordination
+ * (viewport mouse position + active point) that drives the `UnifiedTooltip`;
+ * the chart rendering itself lives in `MiniChart`. Viewport coordinates
+ * (rather than container-relative ones) let the tooltip be portaled to
+ * `document.body` and positioned correctly even when an ancestor applies a
+ * CSS `zoom`.
+ */
+export function MiniChartWrapper({
+  label,
+  data,
+  color,
+  formatValue,
+  isLoading = false,
+  hasValidData = true,
+  isHovered,
+  onTooltipChange,
+  dataTestId
+}: Readonly<MiniChartWrapperProps>) {
+  const handleMouseMove = useCallback(
+    (state: RechartsMouseState, event?: MouseEvent) => {
+      if (state.activeTooltipIndex === undefined || !state.activeLabel) {
+        return
+      }
+
+      if (!event) {
+        onTooltipChange((prev) => ({
+          ...prev,
+          active: true,
+          label: state.activeLabel as string,
+          dataIndex: state.activeTooltipIndex as number
+        }))
+        return
+      }
+
+      onTooltipChange({
+        active: true,
+        label: state.activeLabel,
+        dataIndex: state.activeTooltipIndex,
+        viewportX: event.clientX,
+        viewportY: event.clientY
+      })
+    },
+    [onTooltipChange]
+  )
+
+  const handleMouseLeave = useCallback(() => {
+    onTooltipChange(INACTIVE_TOOLTIP_STATE)
+  }, [onTooltipChange])
+
+  const handleWrapperMouseMove = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      onTooltipChange((prev) => {
+        if (!prev.active) {
+          return prev
+        }
+        return {
+          ...prev,
+          viewportX: event.clientX,
+          viewportY: event.clientY
+        }
+      })
+    },
+    [onTooltipChange]
+  )
+
+  return (
+    <div
+      className={styles.chartHover}
+      onMouseMove={handleWrapperMouseMove}
+    >
+      <MiniChart
+        color={color}
+        data={data}
+        dataTestId={dataTestId}
+        fill
+        formatValue={formatValue}
+        hasValidData={hasValidData}
+        hideLastValue={isHovered}
+        isLoading={isLoading}
+        onMouseLeave={handleMouseLeave}
+        onMouseMove={handleMouseMove}
+        syncId={SYNC_ID}
+        title={label}
+      />
+    </div>
+  )
+}

--- a/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.tsx
@@ -7,8 +7,6 @@ import type { Dispatch, MouseEvent, SetStateAction } from 'react'
 
 import { useCallback } from 'react'
 
-import { EMPTY_STRING } from '#v2/utils/consts'
-
 import { MiniChart } from '../../charts/MiniChart'
 
 import styles from './compactPerformanceChart.module.scss'
@@ -27,14 +25,6 @@ interface MiniChartWrapperProps {
 
 const SYNC_ID = 'compact-performance-chart'
 
-const INACTIVE_TOOLTIP_STATE: TooltipState = {
-  active: false,
-  label: EMPTY_STRING,
-  dataIndex: -1,
-  viewportX: 0,
-  viewportY: 0
-}
-
 /**
  * Wraps the shared `MiniChart` with the cross-chart hover coordination
  * (viewport mouse position + active point) that drives the `UnifiedTooltip`;
@@ -42,6 +32,11 @@ const INACTIVE_TOOLTIP_STATE: TooltipState = {
  * (rather than container-relative ones) let the tooltip be portaled to
  * `document.body` and positioned correctly even when an ancestor applies a
  * CSS `zoom`.
+ *
+ * Deactivation is intentionally owned by the parent container's `onMouseLeave`,
+ * not each chart's: moving between the synced charts crosses the gap between
+ * them, and per-chart leave handling would drop the shared tooltip and flash
+ * the last-value badges back mid-hover.
  */
 export function MiniChartWrapper({
   label,
@@ -81,10 +76,6 @@ export function MiniChartWrapper({
     [onTooltipChange]
   )
 
-  const handleMouseLeave = useCallback(() => {
-    onTooltipChange(INACTIVE_TOOLTIP_STATE)
-  }, [onTooltipChange])
-
   const handleWrapperMouseMove = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
       onTooltipChange((prev) => {
@@ -115,7 +106,6 @@ export function MiniChartWrapper({
         hasValidData={hasValidData}
         hideLastValue={isHovered}
         isLoading={isLoading}
-        onMouseLeave={handleMouseLeave}
         onMouseMove={handleMouseMove}
         syncId={SYNC_ID}
         title={label}

--- a/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/MiniChartWrapper.tsx
@@ -16,14 +16,13 @@ interface MiniChartWrapperProps {
   data: CompactPerformanceDataPoint[]
   color: string
   formatValue: (value: number) => string
+  syncId: string
   isLoading?: boolean
   hasValidData?: boolean
   isHovered: boolean
   onTooltipChange: Dispatch<SetStateAction<TooltipState>>
   dataTestId?: string
 }
-
-const SYNC_ID = 'compact-performance-chart'
 
 /**
  * Wraps the shared `MiniChart` with the cross-chart hover coordination
@@ -43,6 +42,7 @@ export function MiniChartWrapper({
   data,
   color,
   formatValue,
+  syncId,
   isLoading = false,
   hasValidData = true,
   isHovered,
@@ -107,7 +107,7 @@ export function MiniChartWrapper({
         hideLastValue={isHovered}
         isLoading={isLoading}
         onMouseMove={handleMouseMove}
-        syncId={SYNC_ID}
+        syncId={syncId}
         title={label}
       />
     </div>

--- a/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.stories.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.stories.tsx
@@ -41,19 +41,22 @@ const METRICS: UnifiedTooltipMetric[] = [
     data: [THROUGHPUT_POINT],
     label: 'Throughput',
     color: 'var(--cyan-500)',
-    formatValue: formatThroughput
+    formatValue: formatThroughput,
+    hasData: true
   },
   {
     data: [IOPS_POINT],
     label: 'IOPS',
     color: 'var(--aqua-500)',
-    formatValue: formatIops
+    formatValue: formatIops,
+    hasData: true
   },
   {
     data: [LATENCY_POINT],
     label: 'Avg. Latency',
     color: 'var(--orange-500)',
-    formatValue: formatLatency
+    formatValue: formatLatency,
+    hasData: true
   }
 ]
 

--- a/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.stories.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.stories.tsx
@@ -1,0 +1,92 @@
+import type { CompactPerformanceDataPoint, UnifiedTooltipMetric } from './types'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { UnifiedTooltip } from './UnifiedTooltip'
+
+const meta: Meta<typeof UnifiedTooltip> = {
+  title: 'v2/Widgets/CompactPerformanceChart/UnifiedTooltip',
+  component: UnifiedTooltip,
+  tags: ['autodocs']
+}
+
+export default meta
+type Story = StoryObj<typeof UnifiedTooltip>
+
+const TIMESTAMP = 1704067200000
+
+const formatThroughput = (value: number) => `${value.toFixed(1)} MB/s`
+const formatIops = (value: number) => `${value.toFixed(0)} ops`
+const formatLatency = (value: number) => `${value.toFixed(2)} ms`
+
+const THROUGHPUT_POINT: CompactPerformanceDataPoint = {
+  time: '12:00:00',
+  timestamp: TIMESTAMP,
+  value: 180
+}
+
+const IOPS_POINT: CompactPerformanceDataPoint = {
+  time: '12:00:00',
+  timestamp: TIMESTAMP,
+  value: 1800
+}
+
+const LATENCY_POINT: CompactPerformanceDataPoint = {
+  time: '12:00:00',
+  timestamp: TIMESTAMP,
+  value: 1.1
+}
+
+const METRICS: UnifiedTooltipMetric[] = [
+  {
+    data: [THROUGHPUT_POINT],
+    label: 'Throughput',
+    color: 'var(--cyan-500)',
+    formatValue: formatThroughput
+  },
+  {
+    data: [IOPS_POINT],
+    label: 'IOPS',
+    color: 'var(--aqua-500)',
+    formatValue: formatIops
+  },
+  {
+    data: [LATENCY_POINT],
+    label: 'Avg. Latency',
+    color: 'var(--orange-500)',
+    formatValue: formatLatency
+  }
+]
+
+const VIEWPORT_X = 80
+const VIEWPORT_Y = 80
+
+export const Default: Story = {
+  render: () => (
+    <UnifiedTooltip
+      dataIndex={0}
+      label='12:00:00'
+      metrics={METRICS}
+      viewportX={VIEWPORT_X}
+      viewportY={VIEWPORT_Y}
+    />
+  )
+}
+
+const METRICS_WITHOUT_TIMESTAMP: UnifiedTooltipMetric[] = METRICS.map(
+  (metric) => ({
+    ...metric,
+    data: metric.data.map(({ value }) => ({ time: '12:00:00', value }))
+  })
+)
+
+export const NoTimestampFallsBackToLabel: Story = {
+  render: () => (
+    <UnifiedTooltip
+      dataIndex={0}
+      label='12:00:00'
+      metrics={METRICS_WITHOUT_TIMESTAMP}
+      viewportX={VIEWPORT_X}
+      viewportY={VIEWPORT_Y}
+    />
+  )
+}

--- a/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.test.tsx
@@ -3,16 +3,20 @@ import type { CompactPerformanceDataPoint, UnifiedTooltipMetric } from './types'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
+import { EMPTY_CONTENT } from '#consts'
+
 import { UnifiedTooltip } from './UnifiedTooltip'
 
 const buildMetric = (
   label: string,
   color: string,
-  data: CompactPerformanceDataPoint[]
+  data: CompactPerformanceDataPoint[],
+  hasData = true
 ): UnifiedTooltipMetric => ({
   data,
   label,
   color,
+  hasData,
   formatValue: (value) => `${value} u`
 })
 
@@ -125,6 +129,20 @@ describe('UnifiedTooltip', () => {
     )
 
     expect(screen.getByText('12:00:00')).toBeInTheDocument()
+  })
+
+  it('shows a placeholder instead of a formatted value for a metric with no data', () => {
+    render(
+      <UnifiedTooltip
+        {...defaultProps}
+        metrics={[
+          buildMetric('IOPS', 'var(--aqua-500)', [iopsPoint], false)
+        ]}
+      />
+    )
+
+    expect(screen.getByText(EMPTY_CONTENT)).toBeInTheDocument()
+    expect(screen.queryByText('500 u')).not.toBeInTheDocument()
   })
 
   it('returns null when dataIndex is negative', () => {

--- a/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.test.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.test.tsx
@@ -1,0 +1,149 @@
+import type { CompactPerformanceDataPoint, UnifiedTooltipMetric } from './types'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { UnifiedTooltip } from './UnifiedTooltip'
+
+const buildMetric = (
+  label: string,
+  color: string,
+  data: CompactPerformanceDataPoint[]
+): UnifiedTooltipMetric => ({
+  data,
+  label,
+  color,
+  formatValue: (value) => `${value} u`
+})
+
+const throughputPoint: CompactPerformanceDataPoint = {
+  time: '12:00:00',
+  timestamp: 1704067200000,
+  value: 100
+}
+const iopsPoint: CompactPerformanceDataPoint = {
+  time: '12:00:00',
+  timestamp: 1704067200000,
+  value: 500
+}
+const latencyPoint: CompactPerformanceDataPoint = {
+  time: '12:00:00',
+  timestamp: 1704067200000,
+  value: 1
+}
+
+const defaultProps = {
+  dataIndex: 0,
+  label: '12:00:00',
+  metrics: [
+    buildMetric('Throughput', 'var(--cyan-500)', [throughputPoint]),
+    buildMetric('IOPS', 'var(--aqua-500)', [iopsPoint]),
+    buildMetric('Avg. Latency', 'var(--orange-500)', [latencyPoint])
+  ],
+  viewportX: 100,
+  viewportY: 200
+}
+
+const TOOLTIP_SELECTOR = 'div[style]'
+const TOOLTIP_OFFSET_PX = 12
+const TOOLTIP_WIDTH_PX = 200
+const RIGHT_EDGE_OVERFLOW_PX = 5
+const MIN_TOP_PX = 8
+const OUT_OF_VIEWPORT_Y = -50
+
+const getPortaledTooltip = () =>
+  screen.getByText('Throughput').closest<HTMLDivElement>(TOOLTIP_SELECTOR)
+
+describe('UnifiedTooltip', () => {
+  it('renders every metric label and its formatted value in a portal on document.body', () => {
+    render(<UnifiedTooltip {...defaultProps} />)
+
+    expect(screen.getByText('Throughput').closest('body')).toBe(document.body)
+    expect(screen.getByText('Throughput')).toBeInTheDocument()
+    expect(screen.getByText('100 u')).toBeInTheDocument()
+    expect(screen.getByText('IOPS')).toBeInTheDocument()
+    expect(screen.getByText('500 u')).toBeInTheDocument()
+    expect(screen.getByText('Avg. Latency')).toBeInTheDocument()
+    expect(screen.getByText('1 u')).toBeInTheDocument()
+  })
+
+  it('renders the datetime icon', () => {
+    render(<UnifiedTooltip {...defaultProps} />)
+    expect(document.body.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('positions the portaled tooltip near the cursor via CSS custom properties', () => {
+    render(<UnifiedTooltip {...defaultProps} />)
+
+    const tooltip = getPortaledTooltip()
+    expect(tooltip?.style.getPropertyValue('--tooltip-left')).toBe(
+      `${defaultProps.viewportX + TOOLTIP_OFFSET_PX}px`
+    )
+    expect(tooltip?.style.getPropertyValue('--tooltip-top')).toBe(
+      `${defaultProps.viewportY + TOOLTIP_OFFSET_PX}px`
+    )
+  })
+
+  it('flips to the left of the cursor when the tooltip would overflow the right edge', () => {
+    const overflowingViewportX = window.innerWidth - RIGHT_EDGE_OVERFLOW_PX
+
+    render(
+      <UnifiedTooltip
+        {...defaultProps}
+        viewportX={overflowingViewportX}
+      />
+    )
+
+    const tooltip = getPortaledTooltip()
+    expect(tooltip?.style.getPropertyValue('--tooltip-left')).toBe(
+      `${overflowingViewportX - TOOLTIP_OFFSET_PX - TOOLTIP_WIDTH_PX}px`
+    )
+  })
+
+  it('clamps the top position so the tooltip never renders above the viewport', () => {
+    render(
+      <UnifiedTooltip
+        {...defaultProps}
+        viewportY={OUT_OF_VIEWPORT_Y}
+      />
+    )
+
+    const tooltip = getPortaledTooltip()
+    expect(tooltip?.style.getPropertyValue('--tooltip-top')).toBe(`${MIN_TOP_PX}px`)
+  })
+
+  it('falls back to the recharts label when no point carries a timestamp', () => {
+    render(
+      <UnifiedTooltip
+        {...defaultProps}
+        metrics={[
+          buildMetric('Throughput', 'var(--cyan-500)', [
+            { time: '12:00:00', value: 100 }
+          ])
+        ]}
+      />
+    )
+
+    expect(screen.getByText('12:00:00')).toBeInTheDocument()
+  })
+
+  it('returns null when dataIndex is negative', () => {
+    const { container } = render(
+      <UnifiedTooltip
+        {...defaultProps}
+        dataIndex={-1}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('defaults a missing point value to 0', () => {
+    render(
+      <UnifiedTooltip
+        {...defaultProps}
+        dataIndex={5}
+      />
+    )
+    expect(screen.getAllByText('0 u')).toHaveLength(defaultProps.metrics.length)
+  })
+})

--- a/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.tsx
@@ -3,6 +3,8 @@ import type { CSSProperties } from 'react'
 
 import { createPortal } from 'react-dom'
 
+import { EMPTY_CONTENT } from '#consts'
+
 import { DateTimeIcon } from '../../../icons'
 import { formatTooltipTimestamp } from '../../charts/utils/xAxisFormatters'
 
@@ -100,7 +102,9 @@ export function UnifiedTooltip({
             />
             <span className={styles.tooltipMetricLabel}>{metric.label}</span>
             <span className={styles.tooltipMetricValue}>
-              {metric.formatValue(points[index]?.value ?? 0)}
+              {metric.hasData
+                ? metric.formatValue(points[index]?.value ?? 0)
+                : EMPTY_CONTENT}
             </span>
           </div>
         ))}

--- a/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.tsx
+++ b/lib/v2/components/widgets/CompactPerformanceChart/UnifiedTooltip.tsx
@@ -1,0 +1,111 @@
+import type { UnifiedTooltipProps } from './types'
+import type { CSSProperties } from 'react'
+
+import { createPortal } from 'react-dom'
+
+import { DateTimeIcon } from '../../../icons'
+import { formatTooltipTimestamp } from '../../charts/utils/xAxisFormatters'
+
+import styles from './unifiedTooltip.module.scss'
+
+const TOOLTIP_OFFSET_PX = 12
+const TOOLTIP_WIDTH_PX = 200
+const MIN_TOP_PX = 8
+const DATE_ICON_SIZE = 16
+
+interface TooltipPosition {
+  left: number
+  top: number
+}
+
+/**
+ * Fixed-position coordinates for a tooltip anchored near the cursor: offset
+ * down-right by default, flipped to the left of the cursor when it would
+ * overflow the viewport's right edge, and clamped so it never renders above
+ * the viewport's top edge.
+ */
+function calculateTooltipPosition(
+  viewportX: number,
+  viewportY: number
+): TooltipPosition {
+  const overflowsRight =
+    viewportX + TOOLTIP_OFFSET_PX + TOOLTIP_WIDTH_PX > window.innerWidth
+  const left = overflowsRight
+    ? viewportX - TOOLTIP_OFFSET_PX - TOOLTIP_WIDTH_PX
+    : viewportX + TOOLTIP_OFFSET_PX
+
+  const top = Math.max(viewportY + TOOLTIP_OFFSET_PX, MIN_TOP_PX)
+
+  return { left, top }
+}
+
+/**
+ * Combined hover tooltip for the three synced mini charts: a single popover
+ * showing throughput/IOPS/latency at the shared `dataIndex`. Rendered through
+ * a portal into `document.body` with `position: fixed` at the viewport
+ * coordinates so it renders at 1x and tracks the cursor exactly even when an
+ * ancestor applies a CSS `zoom`.
+ */
+export function UnifiedTooltip({
+  dataIndex,
+  label,
+  metrics,
+  viewportX,
+  viewportY,
+  dataTestId
+}: Readonly<UnifiedTooltipProps>) {
+  if (dataIndex < 0) {
+    return null
+  }
+
+  const points = metrics.map((metric) => metric.data[dataIndex])
+  const timestampedPoint = points.find(
+    (point) => point?.timestamp !== undefined
+  )
+  const formattedTimestamp =
+    timestampedPoint?.timestamp !== undefined
+      ? formatTooltipTimestamp(timestampedPoint.timestamp)
+      : label
+
+  const { left, top } = calculateTooltipPosition(viewportX, viewportY)
+
+  const tooltipStyle = {
+    '--tooltip-left': `${left}px`,
+    '--tooltip-top': `${top}px`
+  } as CSSProperties
+
+  return createPortal(
+    <div
+      className={styles.unifiedTooltip}
+      data-testid={dataTestId}
+      style={tooltipStyle}
+    >
+      <div className={styles.tooltipTime}>
+        <DateTimeIcon
+          extraClass={styles.tooltipIcon}
+          height={DATE_ICON_SIZE}
+          width={DATE_ICON_SIZE}
+        />
+        {formattedTimestamp}
+      </div>
+      <div className={styles.tooltipMetrics}>
+        {metrics.map((metric, index) => (
+          <div
+            key={metric.label}
+            className={styles.tooltipMetric}
+          >
+            <div
+              className={styles.tooltipMetricDot}
+              style={{ backgroundColor: metric.color }}
+            />
+            <span className={styles.tooltipMetricLabel}>{metric.label}</span>
+            <span className={styles.tooltipMetricValue}>
+              {metric.formatValue(points[index]?.value ?? 0)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/lib/v2/components/widgets/CompactPerformanceChart/compactPerformanceChart.module.scss
+++ b/lib/v2/components/widgets/CompactPerformanceChart/compactPerformanceChart.module.scss
@@ -1,0 +1,16 @@
+.chartsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  position: relative;
+}
+
+.chartHover {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: visible;
+  position: relative;
+}

--- a/lib/v2/components/widgets/CompactPerformanceChart/index.ts
+++ b/lib/v2/components/widgets/CompactPerformanceChart/index.ts
@@ -1,0 +1,6 @@
+export { CompactPerformanceChart } from './CompactPerformanceChart'
+export type {
+  CompactPerformanceChartProps,
+  CompactPerformanceDataPoint,
+  CompactPerformanceMetricData
+} from './types'

--- a/lib/v2/components/widgets/CompactPerformanceChart/types.ts
+++ b/lib/v2/components/widgets/CompactPerformanceChart/types.ts
@@ -36,6 +36,8 @@ export interface UnifiedTooltipMetric {
   label: string
   color: string
   formatValue: (value: number) => string
+  /** When false the metric is loading or has no real data, so the tooltip shows a placeholder rather than a formatted `0`. */
+  hasData: boolean
 }
 
 export interface UnifiedTooltipProps {

--- a/lib/v2/components/widgets/CompactPerformanceChart/types.ts
+++ b/lib/v2/components/widgets/CompactPerformanceChart/types.ts
@@ -1,0 +1,48 @@
+import type { TimeSeriesPoint } from '../../charts/chartTypes'
+
+export type CompactPerformanceDataPoint = TimeSeriesPoint
+
+export interface CompactPerformanceMetricData {
+  data: CompactPerformanceDataPoint[]
+  isLoading?: boolean
+  hasValidData?: boolean
+  formatValue: (value: number) => string
+  label: string
+  color?: string
+}
+
+export interface CompactPerformanceChartProps {
+  throughput: CompactPerformanceMetricData
+  iops: CompactPerformanceMetricData
+  latency: CompactPerformanceMetricData
+  dataTestId?: string
+}
+
+export interface TooltipState {
+  active: boolean
+  label: string
+  dataIndex: number
+  viewportX: number
+  viewportY: number
+}
+
+export interface RechartsMouseState {
+  activeTooltipIndex?: number
+  activeLabel?: string
+}
+
+export interface UnifiedTooltipMetric {
+  data: CompactPerformanceDataPoint[]
+  label: string
+  color: string
+  formatValue: (value: number) => string
+}
+
+export interface UnifiedTooltipProps {
+  dataIndex: number
+  label: string
+  metrics: UnifiedTooltipMetric[]
+  viewportX: number
+  viewportY: number
+  dataTestId?: string
+}

--- a/lib/v2/components/widgets/CompactPerformanceChart/unifiedTooltip.module.scss
+++ b/lib/v2/components/widgets/CompactPerformanceChart/unifiedTooltip.module.scss
@@ -1,0 +1,77 @@
+.unifiedTooltip {
+  position: fixed;
+  left: var(--tooltip-left);
+  top: var(--tooltip-top);
+  z-index: 2200;
+  pointer-events: none;
+  animation: fade-in-tooltip 0.2s ease-out;
+  background: var(--bg-primary);
+  border: 1px solid var(--gray-600-400);
+  padding: 12px;
+  font-size: 12px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
+  min-width: 160px;
+  border-radius: 4px;
+}
+
+.tooltipTime {
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 14px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tooltipIcon {
+  color: var(--gray-700-300);
+}
+
+.tooltipMetrics {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tooltipMetric {
+  display: grid;
+  grid-template-columns: 8px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.tooltipMetricDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.tooltipMetricLabel {
+  color: var(--text-secondary);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.tooltipMetricValue {
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 11px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+@keyframes fade-in-tooltip {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new v2 shared widget, **`CompactPerformanceChart`** — three `syncId`-synced mini charts (throughput, IOPS, avg. latency) with a unified cross-chart hover tooltip. Prop-only: the caller supplies each metric's data, formatter, and label; the component aligns the three series onto a common timeline internally so hovering one chart drives all three.

## What's included

- **`CompactPerformanceChart`** — the widget, exported from `lib/v2/components/index.ts` along with its `CompactPerformanceChartProps` / `CompactPerformanceDataPoint` / `CompactPerformanceMetricData` types.
- **`MiniChartWrapper`** — wraps the shared `MiniChart` with the cross-chart hover coordination (viewport mouse position + active point) that drives the tooltip.
- **`UnifiedTooltip`** — combined hover popover portaled to `document.body` with `position: fixed`, so it renders at 1x and tracks the cursor even under an ancestor CSS `zoom`.
- **Tooltip stability while active** — the aligned series are frozen for as long as the tooltip stays active, so live-polling `data` updates can't make the inspected point hop under a page transform. Implemented via React's "adjust state during render" pattern.

## Shared data utilities

Time-series helpers live in `lib/v2/components/charts/utils/dataUtils.ts` (not the widget folder) so other charts can reuse them:

- `interpolateValue` — linear interpolation of a value at a target timestamp.
- `generateZeroLineData` — flat zero series for a metric with no data of its own.
- `createCommonTimelineData` — aligns multiple series onto a shared timeline of unique timestamps.

These operate on a new generic `TimeSeriesPoint` added to `charts/chartTypes.ts`; the widget's `CompactPerformanceDataPoint` aliases it.

## Testing

- ESLint clean on all changed files.
- Typecheck clean for all changed v2 files.
- `yarn test:run` — widget + sub-components + moved util tests all pass.
- Storybook stories for `CompactPerformanceChart` (Default, Loading) and `UnifiedTooltip` (Default, NoTimestampFallsBackToLabel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)