### PR TITLE
fix(v2): pad positional series to a common length in createCommonTimelineData (WH-4240)

### DIFF
--- a/lib/v2/components/charts/utils/dataUtils.test.ts
+++ b/lib/v2/components/charts/utils/dataUtils.test.ts
@@ -88,6 +88,40 @@ describe('createCommonTimelineData', () => {
     expect(result.latencyData).toBe(latencyRaw)
   })
 
+  it('pads an empty positional metric to its siblings length to keep index sync', () => {
+    const throughputRaw: TimeSeriesPoint[] = [
+      { time: 't1', value: 100 },
+      { time: 't2', value: 150 }
+    ]
+    const iopsRaw: TimeSeriesPoint[] = []
+    const latencyRaw: TimeSeriesPoint[] = [
+      { time: 't1', value: 1 },
+      { time: 't2', value: 2 }
+    ]
+
+    const result = createCommonTimelineData(throughputRaw, iopsRaw, latencyRaw)
+
+    expect(result.iopsData).toHaveLength(throughputRaw.length)
+    expect(result.iopsData.every((point) => point.value === 0)).toBe(true)
+    expect(result.iopsData.map((point) => point.time)).toEqual(
+      throughputRaw.map((point) => point.time)
+    )
+  })
+
+  it('pads a shorter positional metric with zeros while keeping its real values', () => {
+    const throughputRaw: TimeSeriesPoint[] = [
+      { time: 't1', value: 100 },
+      { time: 't2', value: 150 }
+    ]
+    const iopsRaw: TimeSeriesPoint[] = [{ time: 't1', value: 1000 }]
+
+    const result = createCommonTimelineData(throughputRaw, iopsRaw, [])
+
+    expect(result.iopsData).toHaveLength(throughputRaw.length)
+    expect(result.iopsData[0].value).toBe(iopsRaw[0].value)
+    expect(result.iopsData[1].value).toBe(0)
+  })
+
   it('merges timestamped series onto their union of timestamps', () => {
     const throughputRaw: TimeSeriesPoint[] = [
       { time: 't1', timestamp: FIRST_POINT.timestamp, value: 10 },

--- a/lib/v2/components/charts/utils/dataUtils.ts
+++ b/lib/v2/components/charts/utils/dataUtils.ts
@@ -76,37 +76,73 @@ const toTimestampedValues = (points: TimeSeriesPoint[]): TimestampedValue[] =>
       value: point.value
     }))
 
+interface AlignedSeries {
+  throughputData: TimeSeriesPoint[]
+  iopsData: TimeSeriesPoint[]
+  latencyData: TimeSeriesPoint[]
+}
+
+/**
+ * Pads positional (untimestamped) series to a common length so an empty or
+ * shorter metric still lines up index-for-index with its siblings. Otherwise
+ * `MiniAreaChart` substitutes its 2-point baseline for the short series, which
+ * desyncs `syncId` index hover and lets the tooltip read past its end. Series
+ * that are already the common length are returned untouched.
+ */
+function alignPositionalSeries(
+  throughputRaw: TimeSeriesPoint[],
+  iopsRaw: TimeSeriesPoint[],
+  latencyRaw: TimeSeriesPoint[]
+): AlignedSeries {
+  const maxLength = Math.max(
+    throughputRaw.length,
+    iopsRaw.length,
+    latencyRaw.length
+  )
+  const reference =
+    [throughputRaw, iopsRaw, latencyRaw].find(
+      (points) => points.length === maxLength
+    ) ?? []
+
+  const padToLength = (points: TimeSeriesPoint[]): TimeSeriesPoint[] =>
+    points.length === maxLength
+      ? points
+      : reference.map(
+          (referencePoint, index) =>
+            points[index] ?? { time: referencePoint.time, value: 0 }
+        )
+
+  return {
+    throughputData: padToLength(throughputRaw),
+    iopsData: padToLength(iopsRaw),
+    latencyData: padToLength(latencyRaw)
+  }
+}
+
 /**
  * Aligns three raw series onto a single common timeline so the same array
  * index refers to the same instant in every returned series, letting callers
  * read matching points across all three by one shared index.
  *
- * When none of the incoming points carry a `timestamp`, the series are
- * assumed already positionally aligned (the common case for a single shared
- * data source) and are returned unchanged. Otherwise every unique timestamp
- * across the three series becomes a row, with missing values filled in by
- * interpolation (or a flat zero line for a series with no raw data at all).
+ * When none of the incoming points carry a `timestamp`, the series are assumed
+ * already positionally aligned (the common case for a single shared data
+ * source) and are only padded to a common length so an empty/shorter metric
+ * stays index-aligned. Otherwise every unique timestamp across the three
+ * series becomes a row, with missing values filled in by interpolation (or a
+ * flat zero line for a series with no raw data at all).
  */
 export function createCommonTimelineData(
   throughputRaw: TimeSeriesPoint[],
   iopsRaw: TimeSeriesPoint[],
   latencyRaw: TimeSeriesPoint[]
-): {
-  throughputData: TimeSeriesPoint[]
-  iopsData: TimeSeriesPoint[]
-  latencyData: TimeSeriesPoint[]
-} {
+): AlignedSeries {
   const isTimestamped =
     hasAnyTimestamp(throughputRaw) ||
     hasAnyTimestamp(iopsRaw) ||
     hasAnyTimestamp(latencyRaw)
 
   if (!isTimestamped) {
-    return {
-      throughputData: throughputRaw,
-      iopsData: iopsRaw,
-      latencyData: latencyRaw
-    }
+    return alignPositionalSeries(throughputRaw, iopsRaw, latencyRaw)
   }
 
   const allTimestamps = new Set<number>()


### PR DESCRIPTION
## Summary

Follow-up to #471. In `createCommonTimelineData`'s **untimestamped (positional)** path, the raw series were returned unchanged, so an empty or shorter metric kept a different length from its siblings. `MiniAreaChart` then substitutes its 2-point `BASELINE` for the short series, which:

- desynchronizes `syncId` index-based hover from the sibling charts, and
- lets `UnifiedTooltip` read past the end of that series.

The timestamped path already zero-fills to a common timeline length; this brings the positional path in line.

## Change

- **`dataUtils.ts`** — pad each positional series to the longest series' length, filling gaps with zero-value points that borrow the reference series' `time` labels. Series already at the common length are returned untouched (identity preserved).
- **`dataUtils.test.ts`** — regression tests: an empty positional metric is padded to its siblings' length; a shorter positional metric is padded with zeros while keeping its real values.

## Scope / severity

Narrow: only triggers in positional mode (no timestamps) with unequal-length metrics where the short metric has finished loading (a loading metric renders a skeleton, not the baseline). The `hasData` handling from #471 already shows `—` in the tooltip for an empty metric, so the main remaining symptom this fixes is the **cursor desync** on the short chart.

## Testing

- ESLint + typecheck clean.
- `yarn test:run` on `dataUtils.test.ts` (14) and the full `CompactPerformanceChart` folder (40) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)