### PR TITLE
feat(v2): add maxCount count display to Tabs and Table (WEKAPP-648412)

### DIFF
--- a/lib/v2/components/LoginInput/loginInput.module.scss
+++ b/lib/v2/components/LoginInput/loginInput.module.scss
@@ -81,6 +81,22 @@
   &::placeholder {
     color: $gray-50;
   }
+
+  /*
+   * Chrome repaints autofilled fields with its own background
+   * (input:-internal-autofill-selected), which cannot be overridden
+   * directly. The endless background-color transition means that repaint
+   * never lands, so the input keeps its transparent background, and
+   * -webkit-text-fill-color keeps the login's white text.
+   */
+  &:-webkit-autofill,
+  &:-webkit-autofill:hover,
+  &:-webkit-autofill:focus,
+  &:-webkit-autofill:active {
+    -webkit-text-fill-color: white !important;
+    caret-color: white;
+    transition: background-color 2147483647s ease-out;
+  }
 }
 
 .eyeButton {

--- a/lib/v2/components/Table/CapabilitiesCell/capabilitiesCell.module.scss
+++ b/lib/v2/components/Table/CapabilitiesCell/capabilitiesCell.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   gap: 9px;
-   flex-wrap: nowrap;
+  flex-wrap: nowrap;
   min-width: 0;
   overflow: hidden;
 }

--- a/lib/v2/components/Table/Table/Table.tsx
+++ b/lib/v2/components/Table/Table/Table.tsx
@@ -88,6 +88,8 @@ export interface TableProps<TData = unknown> {
 
   title?: string
   customTitle?: ReactNode
+  /** System maximum for the listed entity; renders the count as "N of MAX". */
+  maxCount?: number
   useTableHeader?: boolean
   tableHeaderActions?: ReactNode
   tableActions?: ReactNode
@@ -143,6 +145,7 @@ export function Table<TData = unknown>({
   pageSize = DEFAULT_PAGE_SIZE,
   title,
   customTitle,
+  maxCount,
   showFilterChips = true,
   showSearch = false,
   tableHeaderActions,
@@ -460,6 +463,7 @@ export function Table<TData = unknown>({
         data={data}
         endless={endless}
         getCsvData={getCsvData}
+        maxCount={maxCount}
         onClearAllFilters={handleClearAllFilters}
         onCsvError={onCsvError}
         onFilterChange={setActiveFilters}

--- a/lib/v2/components/Table/Table/TableHeaderSection/TableHeaderSection.test.tsx
+++ b/lib/v2/components/Table/Table/TableHeaderSection/TableHeaderSection.test.tsx
@@ -69,6 +69,21 @@ describe('TableHeaderSection', () => {
     expect(screen.getByText('(1)')).toBeInTheDocument()
   })
 
+  it('renders the count with the system maximum when maxCount is provided', () => {
+    renderSection({ title: 'Buckets', actualFilteredCount: 2, maxCount: 2048 })
+    expect(screen.getByText('(2 of 2048)')).toBeInTheDocument()
+  })
+
+  it('passes maxCount through to the full TableHeader', () => {
+    renderSection({
+      useTableHeader: true,
+      title: 'Buckets',
+      actualFilteredCount: 2,
+      maxCount: 2048
+    })
+    expect(screen.getByText('(2 of 2048)')).toBeInTheDocument()
+  })
+
   it('renders the full TableHeader when useTableHeader is true', () => {
     renderSection({ useTableHeader: true, title: 'Buckets' })
     expect(screen.getByTestId('table-header-title')).toHaveTextContent(

--- a/lib/v2/components/Table/Table/TableHeaderSection/TableHeaderSection.tsx
+++ b/lib/v2/components/Table/Table/TableHeaderSection/TableHeaderSection.tsx
@@ -5,6 +5,7 @@ import type { ColumnDef, Table } from '@tanstack/react-table'
 import type { ReactNode } from 'react'
 
 import { EMPTY_STRING } from '#v2/utils/consts'
+import { formatCountWithMax } from '#v2/utils/textUtils'
 
 import { FilterChips } from '../../FilterChips'
 import { TableHeader } from '../../TableHeader'
@@ -16,6 +17,7 @@ export interface TableHeaderSectionProps<TData> {
   title?: string
   customTitle?: ReactNode
   actualFilteredCount: number
+  maxCount?: number
   activeFilters: ActiveFilter[]
   showFilterChips: boolean
   showSearch: boolean
@@ -37,12 +39,21 @@ export interface TableHeaderSectionProps<TData> {
   endless?: boolean
 }
 
-function renderTitleSection(
-  title: string | undefined,
-  customTitle: ReactNode,
-  actualFilteredCount: number,
+interface TitleSectionParams {
+  title: string | undefined
+  customTitle: ReactNode
+  actualFilteredCount: number
   endless: boolean
-): ReactNode {
+  maxCount: number | undefined
+}
+
+function renderTitleSection({
+  title,
+  customTitle,
+  actualFilteredCount,
+  endless,
+  maxCount
+}: TitleSectionParams): ReactNode {
   if (customTitle) {
     return <div className={styles.customTitle}>{customTitle}</div>
   }
@@ -50,7 +61,9 @@ function renderTitleSection(
     <>
       <h3 className={styles.tableTitle}>{title}</h3>
       {!endless && actualFilteredCount > 0 ? (
-        <span className={styles.tableCount}>({actualFilteredCount})</span>
+        <span className={styles.tableCount}>
+          ({formatCountWithMax(actualFilteredCount, maxCount)})
+        </span>
       ) : null}
     </>
   )
@@ -61,6 +74,7 @@ export function TableHeaderSection<TData>({
   title,
   customTitle,
   actualFilteredCount,
+  maxCount,
   activeFilters,
   showFilterChips,
   showSearch,
@@ -97,6 +111,7 @@ export function TableHeaderSection<TData>({
         data={data}
         endless={endless}
         getCsvData={getCsvData}
+        maxCount={maxCount}
         onClearAllFilters={onClearAllFilters}
         onCsvError={onCsvError}
         onFilterChange={onFilterChange}
@@ -121,7 +136,13 @@ export function TableHeaderSection<TData>({
     <div className={styles.tableHeader}>
       <div className={styles.titleRow}>
         <div className={styles.titleSection}>
-          {renderTitleSection(title, customTitle, actualFilteredCount, endless)}
+          {renderTitleSection({
+            title,
+            customTitle,
+            actualFilteredCount,
+            endless,
+            maxCount
+          })}
         </div>
         {showFilterChips && hasActiveFilters ? (
           <FilterChips

--- a/lib/v2/components/Table/TableHeader/TableHeader.tsx
+++ b/lib/v2/components/Table/TableHeader/TableHeader.tsx
@@ -13,6 +13,7 @@ import {
   FILTER_TYPES,
   SEARCH_PLACEHOLDER
 } from '#v2/utils/consts'
+import { formatCountWithMax } from '#v2/utils/textUtils'
 
 import { DownloadIcon, ResetIcon, SettingsIcon } from '../../../icons'
 import { ExpandableSearch } from '../../ExpandableSearch'
@@ -64,6 +65,7 @@ export interface TableHeaderProps<TData = unknown> {
   title: string
   customTitle?: ReactNode
   count?: number
+  maxCount?: number
   endless?: boolean
   activeFilters?: readonly ActiveFilter[]
   onRemoveFilter?: (columnId: string) => void
@@ -201,6 +203,7 @@ export function TableHeader({
   customTitle,
   csvFileTitle,
   count,
+  maxCount,
   endless = false,
   activeFilters = EMPTY_ARRAY,
   onRemoveFilter,
@@ -274,10 +277,15 @@ export function TableHeader({
 
   const renderCount = useCallback(() => {
     const displayCount = getDisplayCount()
-    return displayCount !== undefined ? (
-      <span className={styles.count}>({displayCount})</span>
-    ) : null
-  }, [getDisplayCount])
+    if (displayCount === undefined) {
+      return null
+    }
+    return (
+      <span className={styles.count}>
+        ({formatCountWithMax(displayCount, maxCount)})
+      </span>
+    )
+  }, [getDisplayCount, maxCount])
 
   const handleAddToFilter = useCallback(
     (value: string) => {

--- a/lib/v2/components/Tabs/TabCount/TabCount.test.tsx
+++ b/lib/v2/components/Tabs/TabCount/TabCount.test.tsx
@@ -1,0 +1,57 @@
+import type { Tab } from '../tabsConstants'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { TAB_VARIANTS } from '../tabsConstants'
+import { TabCount } from './TabCount'
+
+const baseTab: Tab = { id: 'tab-1', label: 'Tab 1' }
+const COUNT = 2
+const MAX_COUNT = 1024
+
+describe('TabCount', () => {
+  it('renders nothing when the tab has no count', () => {
+    const { container } = render(
+      <TabCount
+        tab={baseTab}
+        variant={TAB_VARIANTS.UNDERLINE}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('wraps the count in parentheses for the underline variant', () => {
+    render(
+      <TabCount
+        tab={{ ...baseTab, count: COUNT }}
+        variant={TAB_VARIANTS.UNDERLINE}
+      />
+    )
+
+    expect(screen.getByText(`(${COUNT})`)).toBeInTheDocument()
+  })
+
+  it('renders the bare count for the primary variant', () => {
+    render(
+      <TabCount
+        tab={{ ...baseTab, count: COUNT }}
+        variant={TAB_VARIANTS.PRIMARY}
+      />
+    )
+
+    expect(screen.getByText(COUNT)).toBeInTheDocument()
+  })
+
+  it('renders the count with its maximum when maxCount is provided', () => {
+    render(
+      <TabCount
+        tab={{ ...baseTab, count: COUNT, maxCount: MAX_COUNT }}
+        variant={TAB_VARIANTS.UNDERLINE}
+      />
+    )
+
+    expect(screen.getByText(`(${COUNT} of ${MAX_COUNT})`)).toBeInTheDocument()
+  })
+})

--- a/lib/v2/components/Tabs/TabCount/TabCount.tsx
+++ b/lib/v2/components/Tabs/TabCount/TabCount.tsx
@@ -1,0 +1,25 @@
+import type { Tab, TabVariant } from '../tabsConstants'
+
+import { formatCountWithMax } from '#v2/utils/textUtils'
+
+import { TAB_VARIANTS } from '../tabsConstants'
+
+import styles from '../tabs.module.scss'
+
+interface TabCountProps {
+  tab: Tab
+  variant: TabVariant
+}
+
+export function TabCount({ tab, variant }: Readonly<TabCountProps>) {
+  if (tab.count === undefined) {
+    return null
+  }
+
+  const countText = formatCountWithMax(tab.count, tab.maxCount)
+  return (
+    <span className={styles.tabCount}>
+      {variant === TAB_VARIANTS.UNDERLINE ? `(${countText})` : countText}
+    </span>
+  )
+}

--- a/lib/v2/components/Tabs/TabCount/index.ts
+++ b/lib/v2/components/Tabs/TabCount/index.ts
@@ -1,0 +1,1 @@
+export { TabCount } from './TabCount'

--- a/lib/v2/components/Tabs/Tabs.stories.tsx
+++ b/lib/v2/components/Tabs/Tabs.stories.tsx
@@ -33,6 +33,7 @@ const BASIC_TABS: Tab[] = [
 const UNDERLINE_TABS: Tab[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'alerts', label: 'Alerts', count: 4 },
+  { id: 'filesystems', label: 'Filesystems', count: 2, maxCount: 1024 },
   { id: 'audit', label: 'Audit log' }
 ]
 

--- a/lib/v2/components/Tabs/Tabs.test.tsx
+++ b/lib/v2/components/Tabs/Tabs.test.tsx
@@ -96,6 +96,26 @@ describe('Tabs - Rendering', () => {
     expect(screen.getByText('(42)')).toBeInTheDocument()
   })
 
+  it('renders the count with its maximum when maxCount is provided', () => {
+    render(
+      <Tabs
+        {...createProps({
+          variant: TAB_VARIANTS.UNDERLINE,
+          tabs: [
+            createTab({
+              id: TAB_ONE_ID,
+              label: TAB_ONE_LABEL,
+              count: 2,
+              maxCount: 1024
+            })
+          ]
+        })}
+      />
+    )
+
+    expect(screen.getByText('(2 of 1024)')).toBeInTheDocument()
+  })
+
   it('renders tab label text', () => {
     render(<Tabs {...createProps()} />)
     expect(screen.getByText(TAB_ONE_LABEL)).toBeInTheDocument()

--- a/lib/v2/components/Tabs/Tabs.tsx
+++ b/lib/v2/components/Tabs/Tabs.tsx
@@ -22,6 +22,7 @@ import { Tooltip } from '../Tooltip'
 import { AddTabButton } from './AddTabButton'
 import { useTabsCarousel, useTabsDerivedState } from './hooks'
 import { ScrollArrow } from './ScrollArrow'
+import { TabCount } from './TabCount'
 import { TabEditableActions } from './TabEditableActions'
 import { TabIcon } from './TabIcon'
 import {
@@ -537,9 +538,6 @@ export function Tabs({
       )
     }
 
-    const countDisplay =
-      variant === TAB_VARIANTS.UNDERLINE ? `(${tab.count})` : tab.count
-
     return (
       <>
         <TabIcon
@@ -559,9 +557,10 @@ export function Tabs({
             {tab.label}
           </Tooltip>
         )}
-        {tab.count !== undefined && (
-          <span className={styles.tabCount}>{countDisplay}</span>
-        )}
+        <TabCount
+          tab={tab}
+          variant={variant}
+        />
         {isEditable ? (
           <TabEditableActions
             canDelete={canDelete}

--- a/lib/v2/components/Tabs/tabs.module.scss
+++ b/lib/v2/components/Tabs/tabs.module.scss
@@ -47,7 +47,7 @@
       color: var(--gray-450-550);
       text-decoration: none;
       border-bottom: none;
-      font-size: 20px;
+      font-size: 16px;
       font-weight: 400;
       background: none;
       border-radius: 0;

--- a/lib/v2/components/Tabs/tabsConstants.ts
+++ b/lib/v2/components/Tabs/tabsConstants.ts
@@ -22,6 +22,7 @@ export interface Tab {
   icon?: ReactNode
   Icon?: ComponentType<{ width?: number; height?: number; color?: string }>
   count?: number
+  maxCount?: number
   subTab?: string
   isLocked?: boolean
 }

--- a/lib/v2/components/widgets/CapacityWidget/capacityWidget.module.scss
+++ b/lib/v2/components/widgets/CapacityWidget/capacityWidget.module.scss
@@ -332,7 +332,7 @@ $capsule-radius: 50px;
   width: 358px;
   max-width: 100%;
   height: 30px;
-  padding: 1px 8px 2px 8px;
+  padding: 1px 8px 2px;
   background-color: var(--gray-200-800);
   border-radius: 0;
 }
@@ -360,17 +360,86 @@ $capsule-radius: 50px;
   align-self: flex-start;
 }
 
+@container (width <= 700px) {
+  .usableBody {
+    gap: 12px;
+  }
+
+  .provisionedBody {
+    width: auto;
+    max-width: 100%;
+  }
+
+  .provisionedBody.provisionedBodyNoObsNoDr {
+    gap: 12px;
+  }
+
+  .provisionedBodyNoObs .tierBlock {
+    gap: 12px;
+  }
+
+  .capsules {
+    gap: 12px;
+  }
+
+  .provisionedSection {
+    padding-left: 12px;
+    padding-right: 4px;
+  }
+
+  .provisionedLegend {
+    .legendLabel {
+      font-size: 12px;
+      white-space: normal;
+    }
+
+    .number {
+      font-size: 18px;
+    }
+
+    .unit {
+      font-size: 14px;
+    }
+  }
+
+  .totalProvisionedItem {
+    .legendLabel {
+      font-size: 14px;
+      white-space: normal;
+    }
+
+    .number {
+      font-size: 18px;
+    }
+
+    .unit {
+      font-size: 14px;
+    }
+  }
+
+  .provisionedSection .totalPill {
+    width: auto;
+    max-width: 100%;
+  }
+
+  .provisionedSection .totalLabel {
+    font-size: 12px;
+    white-space: normal;
+  }
+
+  .capsuleLabel {
+    font-size: 12px;
+    line-height: 14px;
+  }
+}
+
 @container (width <= 600px) {
   .divider {
     margin: 4px;
   }
 
   .usableSection {
-    flex: 0 0 350px;
-  }
-
-  .usableBody {
-    gap: 14px;
+    flex: 0 0 320px;
   }
 
   .usableBodyNoDr {
@@ -414,10 +483,6 @@ $capsule-radius: 50px;
   .provisionedSection {
     padding-left: 10px;
     padding-right: 0;
-  }
-
-  .provisionedSection .totalPill {
-    width: 200px;
   }
 
   .provisionedSection .totalLabel {

--- a/lib/v2/components/widgets/InventoryCard/InventoryCard.stories.tsx
+++ b/lib/v2/components/widgets/InventoryCard/InventoryCard.stories.tsx
@@ -10,45 +10,54 @@ const meta: Meta<typeof InventoryCard> = {
 export default meta
 type Story = StoryObj<typeof InventoryCard>
 
-const wrapperStyle = { width: '360px' }
+const defaultData = [
+  {
+    id: 'servers',
+    title: 'Servers',
+    subtitle: 'Active / Total',
+    value: '8 / 10',
+    description: '80% active',
+    percentage: 80
+  },
+  {
+    id: 'drivers',
+    title: 'Drives',
+    subtitle: 'Active / Total',
+    value: '32 / 32',
+    description: '100% active',
+    percentage: 100
+  },
+  {
+    id: 'filesystems',
+    title: 'Filesystems',
+    subtitle: 'Total',
+    value: '5',
+    description: 'Filesystems'
+  },
+  {
+    id: 's3buckets',
+    title: 'S3 Buckets',
+    subtitle: 'Total',
+    value: '2',
+    description: 'Buckets'
+  }
+] as const
+
+const defaultWrapperStyle = { width: '360px' }
+const narrowWrapperStyle = { width: '280px', height: '240px' }
 
 export const Default: Story = {
   render: () => (
-    <div style={wrapperStyle}>
-      <InventoryCard
-        data={[
-          {
-            id: 'servers',
-            title: 'Servers',
-            subtitle: 'Active / Total',
-            value: '8 / 10',
-            description: '80% active',
-            percentage: 80
-          },
-          {
-            id: 'drivers',
-            title: 'Drives',
-            subtitle: 'Active / Total',
-            value: '32 / 32',
-            description: '100% active',
-            percentage: 100
-          },
-          {
-            id: 'filesystems',
-            title: 'Filesystems',
-            subtitle: 'Total',
-            value: '5',
-            description: 'Filesystems'
-          },
-          {
-            id: 's3buckets',
-            title: 'S3 Buckets',
-            subtitle: 'Total',
-            value: '2',
-            description: 'Buckets'
-          }
-        ]}
-      />
+    <div style={defaultWrapperStyle}>
+      <InventoryCard data={[...defaultData]} />
+    </div>
+  )
+}
+
+export const Narrow: Story = {
+  render: () => (
+    <div style={narrowWrapperStyle}>
+      <InventoryCard data={[...defaultData]} />
     </div>
   )
 }

--- a/lib/v2/components/widgets/InventoryCard/inventoryCard.module.scss
+++ b/lib/v2/components/widgets/InventoryCard/inventoryCard.module.scss
@@ -16,6 +16,94 @@
   align-items: center;
   padding: 12px 8px;
   flex: 1;
+  min-width: 0;
+  gap: 8px;
+}
+
+.leftSection {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.iconContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  svg {
+    width: 36px;
+    height: 36px;
+  }
+}
+
+.textSection {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--gray-900-100);
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.subtitle {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--gray-900-100);
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rightSection {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.value {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--gray-900-100);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.description {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--gray-900-100);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+@container (width <= 300px) {
+  .inventoryItem {
+    padding: 10px 8px;
+  }
+
+  .leftSection {
+    gap: 10px;
+  }
+
+  .iconContainer svg {
+    width: 32px;
+    height: 32px;
+  }
 }
 
 @container (height <= 244px) {
@@ -37,60 +125,6 @@
   &:hover {
     background-color: var(--gray-50-920);
   }
-}
-
-.leftSection {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.iconContainer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.textSection {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.title {
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--gray-900-100);
-  line-height: 1.2;
-}
-
-.subtitle {
-  font-size: 12px;
-  font-weight: 400;
-  color: var(--gray-900-100);
-  line-height: 1.2;
-}
-
-.rightSection {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 2px;
-}
-
-.value {
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--gray-900-100);
-  line-height: 1.2;
-}
-
-.description {
-  font-size: 12px;
-  font-weight: 400;
-  color: var(--gray-900-100);
-  line-height: 1.2;
 }
 
 .warningText {

--- a/lib/v2/utils/index.ts
+++ b/lib/v2/utils/index.ts
@@ -78,7 +78,11 @@ export {
   PROTECTION_STATUS_MAP,
   PROTECTION_STATUS_TYPES
 } from '#v2/utils/protectionStatus'
-export { highlightText, truncateText } from '#v2/utils/textUtils'
+export {
+  formatCountWithMax,
+  highlightText,
+  truncateText
+} from '#v2/utils/textUtils'
 export type { TimestampInput } from '#v2/utils/timeUtils'
 export {
   formatDate,

--- a/lib/v2/utils/textUtils.test.ts
+++ b/lib/v2/utils/textUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { truncateText } from '#v2/utils/textUtils'
+import { formatCountWithMax, truncateText } from '#v2/utils/textUtils'
 
 const MAX_LENGTH = 13
 
@@ -18,5 +18,20 @@ describe('truncateText', () => {
 
     expect(result).toBe('a-very-lon...')
     expect(result).toHaveLength(MAX_LENGTH)
+  })
+})
+
+const COUNT = 42
+const MAX_COUNT = 1024
+
+describe('formatCountWithMax', () => {
+  it('returns the count alone when no maximum is provided', () => {
+    expect(formatCountWithMax(COUNT)).toBe(`${COUNT}`)
+  })
+
+  it('appends the maximum when provided', () => {
+    expect(formatCountWithMax(COUNT, MAX_COUNT)).toBe(
+      `${COUNT} of ${MAX_COUNT}`
+    )
   })
 })

--- a/lib/v2/utils/textUtils.tsx
+++ b/lib/v2/utils/textUtils.tsx
@@ -18,6 +18,14 @@ export function truncateText(text: string, maxLength: number): string {
 }
 
 /**
+ * Formats a count for display, appending the maximum when provided
+ * (e.g. `2 of 1024`).
+ */
+export function formatCountWithMax(count: number, maxCount?: number): string {
+  return maxCount === undefined ? String(count) : `${count} of ${maxCount}`
+}
+
+/**
  * Wraps occurrences of `query` in `text` with a given element to highlight matches.
  * Case-insensitive. Returns ReactNode parts so React keys can be applied.
  */


### PR DESCRIPTION
## Summary
- **Tabs**: add an optional `maxCount` field to the `Tab` interface; when provided, the tab count renders as `count of maxCount` (e.g. `(2 of 1024)` in the underline variant). Also reduce underline tab font size from 20px to 16px.
- **Table**: add an optional `maxCount` prop to `Table`, threaded through `TableHeaderSection` and `TableHeader`, so the header count renders as `(2 of 2048)` when a system maximum is provided.

## Additional fixes
- **LoginInput**: keep the transparent background and white text when Chrome autofills the field (`:-webkit-autofill` override with an endless background-color transition).
- **InventoryCard**: responsive layout — text truncation with ellipsis, icon sizing, `flex`/`min-width` fixes, narrow-container (≤300px) styles — plus a new `Narrow` Storybook story.
- **CapacityWidget**: responsive styles for containers ≤700px (tighter gaps, smaller legend/label fonts, flexible pill widths).
- **CapabilitiesCell**: indentation fix.

## Testing
- New tests: `maxCount` rendering in Tabs, and in `TableHeaderSection` (both the compact title section and the full `TableHeader` path).
- All Tabs tests (26) and Table tests (320 across 40 files) pass.
- ESLint and stylelint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)