### PR TITLE
fix(v2): let the no-OBS capacity capsule fill its freed column height

### DIFF
--- a/lib/v2/components/widgets/CapacityWidget/CapacityWidget.stories.tsx
+++ b/lib/v2/components/widgets/CapacityWidget/CapacityWidget.stories.tsx
@@ -234,6 +234,13 @@ export const NoObsNoDr531x212 = makeVariant({
   dataReduction: false
 })
 
+export const NoObsNoDr736x400 = makeVariant({
+  width: 736,
+  height: 400,
+  obs: false,
+  dataReduction: false
+})
+
 export const CustomLabels: Story = {
   render: (args) => (
     <Frame

--- a/lib/v2/components/widgets/CapacityWidget/capacityWidget.module.scss
+++ b/lib/v2/components/widgets/CapacityWidget/capacityWidget.module.scss
@@ -67,15 +67,21 @@ $capsule-radius: 50px;
 }
 
 .provisionedBody.provisionedBodyNoObs {
+  flex: 1 1 auto;
   width: auto;
+  min-height: 0;
   gap: 12px;
   padding-bottom: 0;
-  align-self: flex-start;
+  align-self: stretch;
   justify-content: flex-start;
 }
 
 .provisionedBody.provisionedBodyNoObsNoDr {
   gap: 24px;
+}
+
+.provisionedBodyNoObs .capsules {
+  align-self: stretch;
 }
 
 .provisionedBodyNoObs .tierBlock {
@@ -287,7 +293,12 @@ $capsule-radius: 50px;
 
 .capsuleBarWide {
   width: 36px;
-  height: 230px;
+}
+
+.provisionedBodyNoObs .capsuleBarWide {
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 160px;
 }
 
 .capsuleFill {
@@ -509,10 +520,6 @@ $capsule-radius: 50px;
 
   .capsuleBar {
     height: 160px;
-  }
-
-  .capsuleBarWide {
-    height: 190px;
   }
 
   .provisionedBody {


### PR DESCRIPTION
## Problem

In the `CapacityWidget`, the wide SSD capsule (the no-OBS variant, `wide={!hasObs}`) carried hardcoded heights — `230px`, and `190px` inside the `@container (height <= 240px)` query. Those were tuned for the 252px and 212px design frames.

Those numbers are really *"card height minus the SSD label"* (`230 = 252 − 22`, `190 = 212 − 22`). The design intent is that when there is no OBS tier there is no bottom `TotalPill`, so the bar takes the space that frees up.

Freezing that as a constant breaks for any consumer that lifts the widget's `max-height`. The NeuralMesh dashboard does exactly that (`max-height: none` on both the card and the widget), so at tall viewports — reported at 960px — the bar stayed pinned at 230px inside a much taller card and no longer filled the freed column.

## Change

- `.provisionedBody.provisionedBodyNoObs` now stretches (`flex: 1 1 auto`, `align-self: stretch`, `min-height: 0`) instead of hugging its content, and its `.capsules` stretches with it.
- `.provisionedBodyNoObs .capsuleBarWide` grows into that space (`flex: 1 1 auto`, `height: auto`, `min-height: 160px`) rather than declaring a fixed height.
- Dropped the fixed `height: 230px` and the now-dead `height: 190px` container-query override.
- Untouched: the donut heights, the narrow `.capsuleBar` heights, and the entire two-capsule OBS layout. `wide` is only ever true when OBS is absent.

## Verification

Measured in headless Chrome against the compiled stylesheet:

| Container height | Measured bar | Design |
| --- | --- | --- |
| 252px (Max Height) | 232px | 230px |
| 212px (Min Height) | 192px | 190px |
| 400px (tall consumer card) | 380px | grows — the fix |

The 2px delta is the design's rounding of the same `container − 22` relationship.

- `stylelint`, `eslint`, `prettier --check` clean on both files
- `CapacityWidget` vitest suite: 6 files / 33 tests passing

## Storybook

Adds a `NoObsNoDr736x400` story. The existing frames topped out at 252px, which is why this tall-container case was never reviewable.

## Test plan

- [ ] Review `NoObsNoDr736x400` alongside the existing no-OBS frames — bar should fill down to the SSD label
- [ ] Confirm the `+ OBS` variants (both widths, both heights) are visually unchanged
- [ ] Check the `width <= 700px` / `width <= 600px` narrow frames

Made with [Cursor](https://cursor.com)