### PR TITLE
fix(v2): add 10px top padding to the capacity capsule content

### DIFF
--- a/lib/v2/components/widgets/CapacityWidget/capacityWidget.module.scss
+++ b/lib/v2/components/widgets/CapacityWidget/capacityWidget.module.scss
@@ -279,6 +279,7 @@ $capsule-radius: 50px;
   flex-direction: column;
   gap: 2px;
   align-items: center;
+  padding-top: 10px;
 }
 
 .capsuleBar {


### PR DESCRIPTION
Adds `padding-top: 10px` to the capacity capsule content so the capsule doesn't touch the top edge of its freed column (follow-up to #474).

🤖 Generated with [Claude Code](https://claude.com/claude-code)