### PR TITLE
feat(v2): AllocationBar, ToggleSection and Popup enhancements for the Create Filesystem popup (WEKAPP-661636)

### DIFF
--- a/lib/v2/components/AllocationBar/AllocationBar.stories.tsx
+++ b/lib/v2/components/AllocationBar/AllocationBar.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { ALLOCATION_SEGMENT_TONES, AllocationBar } from './AllocationBar'
+
+const CLUSTER_SSD_ALLOCATION = 'Cluster SSD Allocation'
+const TOTAL_LABEL = '120.8 TB total'
+const TOTAL_TB = 120.8
+const USED_SEGMENT = {
+  id: 'used',
+  label: 'Used',
+  value: 62.24,
+  valueDisplay: '62.24 TB',
+  tone: ALLOCATION_SEGMENT_TONES.USED
+}
+
+const meta: Meta<typeof AllocationBar> = {
+  title: 'v2/AllocationBar',
+  component: AllocationBar
+}
+
+export default meta
+type Story = StoryObj<typeof AllocationBar>
+
+export const Standard: Story = {
+  args: {
+    label: CLUSTER_SSD_ALLOCATION,
+    totalLabel: TOTAL_LABEL,
+    total: TOTAL_TB,
+    segments: [
+      USED_SEGMENT,
+      {
+        id: 'thisFs',
+        label: 'This Filesystem',
+        value: 10.21,
+        valueDisplay: '10.21 TB',
+        tone: ALLOCATION_SEGMENT_TONES.PRIMARY
+      },
+      {
+        id: 'free',
+        label: 'Free',
+        value: 48.35,
+        valueDisplay: '48.35 TB',
+        tone: ALLOCATION_SEGMENT_TONES.FREE
+      }
+    ]
+  }
+}
+
+export const ThinProvision: Story = {
+  args: {
+    label: CLUSTER_SSD_ALLOCATION,
+    totalLabel: TOTAL_LABEL,
+    total: TOTAL_TB,
+    segments: [
+      USED_SEGMENT,
+      {
+        id: 'reserved',
+        label: 'Reserved SSD',
+        value: 10.21,
+        valueDisplay: '10.21 TB',
+        tone: ALLOCATION_SEGMENT_TONES.PRIMARY
+      },
+      {
+        id: 'maxSsd',
+        label: 'Max SSD',
+        value: 8.21,
+        valueDisplay: '8.21 TB',
+        tone: ALLOCATION_SEGMENT_TONES.PRIMARY_LIGHT
+      },
+      {
+        id: 'free',
+        label: 'Free',
+        value: 40.14,
+        valueDisplay: '40.14 TB',
+        tone: ALLOCATION_SEGMENT_TONES.FREE
+      }
+    ]
+  }
+}
+
+export const OverAllocated: Story = {
+  args: {
+    label: CLUSTER_SSD_ALLOCATION,
+    totalLabel: TOTAL_LABEL,
+    total: TOTAL_TB,
+    errorMessage:
+      'Exceeds free SSD capacity by 3.44 TB. Reduce capacity or enable Thin Provision.',
+    segments: [
+      USED_SEGMENT,
+      {
+        id: 'thisFs',
+        label: 'This Filesystem',
+        value: 62,
+        valueDisplay: '62 TB',
+        tone: ALLOCATION_SEGMENT_TONES.ERROR
+      },
+      {
+        id: 'free',
+        label: 'Free',
+        value: 0,
+        valueDisplay: '0 TB',
+        tone: ALLOCATION_SEGMENT_TONES.FREE
+      }
+    ]
+  }
+}

--- a/lib/v2/components/AllocationBar/AllocationBar.test.tsx
+++ b/lib/v2/components/AllocationBar/AllocationBar.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { ALLOCATION_SEGMENT_TONES, AllocationBar } from './AllocationBar'
+
+const TEST_ID = 'ssd-allocation'
+
+const BASE_SEGMENTS = [
+  {
+    id: 'used',
+    label: 'Used',
+    value: 60,
+    valueDisplay: '60 TB',
+    tone: ALLOCATION_SEGMENT_TONES.USED
+  },
+  {
+    id: 'thisFs',
+    label: 'This Filesystem',
+    value: 10,
+    valueDisplay: '10 TB',
+    tone: ALLOCATION_SEGMENT_TONES.PRIMARY
+  },
+  {
+    id: 'free',
+    label: 'Free',
+    value: 30,
+    valueDisplay: '30 TB',
+    tone: ALLOCATION_SEGMENT_TONES.FREE
+  }
+]
+
+describe('AllocationBar', () => {
+  it('renders a legend entry per segment with label and value', () => {
+    render(
+      <AllocationBar
+        segments={BASE_SEGMENTS}
+        total={100}
+      />
+    )
+
+    expect(screen.getByText('Used')).toBeInTheDocument()
+    expect(screen.getByText('60 TB')).toBeInTheDocument()
+    expect(screen.getByText('This Filesystem')).toBeInTheDocument()
+    expect(screen.getByText('Free')).toBeInTheDocument()
+    expect(screen.getByText('30 TB')).toBeInTheDocument()
+  })
+
+  it('renders bar slices sized by value share, excluding FREE segments', () => {
+    render(
+      <AllocationBar
+        dataTestId={TEST_ID}
+        segments={BASE_SEGMENTS}
+        total={100}
+      />
+    )
+
+    expect(screen.getByTestId(`${TEST_ID}-segment-used`).style.width).toBe(
+      '60%'
+    )
+    expect(screen.getByTestId(`${TEST_ID}-segment-thisFs`).style.width).toBe(
+      '10%'
+    )
+    expect(
+      screen.queryByTestId(`${TEST_ID}-segment-free`)
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId(`${TEST_ID}-legend-free`)).toBeInTheDocument()
+  })
+
+  it('clamps slice widths so the bar never exceeds 100%', () => {
+    const overflowingSegments = [
+      { ...BASE_SEGMENTS[0], value: 80 },
+      { ...BASE_SEGMENTS[1], value: 50 }
+    ]
+    render(
+      <AllocationBar
+        dataTestId={TEST_ID}
+        segments={overflowingSegments}
+        total={100}
+      />
+    )
+
+    expect(screen.getByTestId(`${TEST_ID}-segment-used`).style.width).toBe(
+      '80%'
+    )
+    expect(screen.getByTestId(`${TEST_ID}-segment-thisFs`).style.width).toBe(
+      '20%'
+    )
+  })
+
+  it('omits slices for zero-value segments but keeps their legend entry', () => {
+    const segmentsWithZero = [
+      BASE_SEGMENTS[0],
+      { ...BASE_SEGMENTS[1], value: 0 }
+    ]
+    render(
+      <AllocationBar
+        dataTestId={TEST_ID}
+        segments={segmentsWithZero}
+        total={100}
+      />
+    )
+
+    expect(
+      screen.queryByTestId(`${TEST_ID}-segment-thisFs`)
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId(`${TEST_ID}-legend-thisFs`)).toBeInTheDocument()
+  })
+
+  it('renders no slices when total is zero', () => {
+    render(
+      <AllocationBar
+        dataTestId={TEST_ID}
+        segments={BASE_SEGMENTS}
+        total={0}
+      />
+    )
+
+    expect(
+      screen.queryByTestId(`${TEST_ID}-segment-used`)
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the header label and right-aligned total label', () => {
+    render(
+      <AllocationBar
+        label='Cluster SSD Allocation'
+        segments={BASE_SEGMENTS}
+        total={100}
+        totalLabel='100 TB total'
+      />
+    )
+
+    expect(screen.getByText('Cluster SSD Allocation')).toBeInTheDocument()
+    expect(screen.getByText('100 TB total')).toBeInTheDocument()
+  })
+
+  it('renders the error message as an alert with error styling', () => {
+    const errorSegments = [
+      BASE_SEGMENTS[0],
+      { ...BASE_SEGMENTS[1], tone: ALLOCATION_SEGMENT_TONES.ERROR }
+    ]
+    render(
+      <AllocationBar
+        dataTestId={TEST_ID}
+        errorMessage='Exceeds free SSD capacity by 3.44 TB.'
+        segments={errorSegments}
+        total={100}
+      />
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('Exceeds free SSD capacity by 3.44 TB.')
+    expect(screen.getByTestId(`${TEST_ID}-segment-thisFs`).className).toMatch(
+      /error/
+    )
+  })
+
+  it('renders no alert when errorMessage is absent', () => {
+    render(
+      <AllocationBar
+        segments={BASE_SEGMENTS}
+        total={100}
+      />
+    )
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('applies extraClass to the container', () => {
+    const EXTRA = 'custom-allocation'
+    const { container } = render(
+      <AllocationBar
+        extraClass={EXTRA}
+        segments={BASE_SEGMENTS}
+        total={100}
+      />
+    )
+
+    expect(container.querySelector(`.${EXTRA}`)).toBeInTheDocument()
+  })
+})

--- a/lib/v2/components/AllocationBar/AllocationBar.tsx
+++ b/lib/v2/components/AllocationBar/AllocationBar.tsx
@@ -1,0 +1,146 @@
+import clsx from 'clsx'
+
+import { PERCENTAGE } from '#v2/utils/consts'
+
+import { WarningCircleIcon } from '../../icons'
+
+import styles from './allocationBar.module.scss'
+
+export const ALLOCATION_SEGMENT_TONES = {
+  USED: 'used',
+  PRIMARY: 'primary',
+  PRIMARY_LIGHT: 'primaryLight',
+  FREE: 'free',
+  ERROR: 'error'
+} as const
+
+export type AllocationSegmentTone =
+  (typeof ALLOCATION_SEGMENT_TONES)[keyof typeof ALLOCATION_SEGMENT_TONES]
+
+export interface AllocationBarSegment {
+  id: string
+  label: string
+  value: number
+  valueDisplay?: string
+  tone: AllocationSegmentTone
+}
+
+export interface AllocationBarProps {
+  segments: AllocationBarSegment[]
+  total: number
+  label?: string
+  totalLabel?: string
+  errorMessage?: string
+  height?: number
+  extraClass?: string
+  dataTestId?: string
+}
+
+const DEFAULT_BAR_HEIGHT = 24
+const ERROR_ICON_SIZE = 14
+
+function getSliceWidths(
+  segments: AllocationBarSegment[],
+  total: number
+): number[] {
+  let remainingPercentage: number = PERCENTAGE.FULL
+  return segments.map((segment) => {
+    if (total <= 0 || segment.value <= 0) {
+      return 0
+    }
+    const percentage = Math.min(
+      (segment.value / total) * PERCENTAGE.FULL,
+      remainingPercentage
+    )
+    remainingPercentage -= percentage
+    return percentage
+  })
+}
+
+/**
+ * A multi-segment horizontal allocation bar with a legend, an optional
+ * header row (label + right-aligned total), and an optional inline error
+ * line. Prop-only: values are plain numbers and display strings are
+ * supplied pre-formatted by the caller. Segments with the FREE tone appear
+ * in the legend only — the bar track itself represents free space.
+ */
+export function AllocationBar({
+  segments,
+  total,
+  label,
+  totalLabel,
+  errorMessage,
+  height = DEFAULT_BAR_HEIGHT,
+  extraClass,
+  dataTestId
+}: Readonly<AllocationBarProps>) {
+  const barSegments = segments.filter(
+    (segment) => segment.tone !== ALLOCATION_SEGMENT_TONES.FREE
+  )
+  const sliceWidths = getSliceWidths(barSegments, total)
+
+  return (
+    <div
+      className={clsx(styles.allocationBar, extraClass)}
+      data-testid={dataTestId}
+    >
+      {label || totalLabel ? (
+        <div className={styles.headerRow}>
+          {label ? <span className={styles.label}>{label}</span> : null}
+          {totalLabel ? (
+            <span className={styles.totalLabel}>{totalLabel}</span>
+          ) : null}
+        </div>
+      ) : null}
+      <div
+        className={styles.track}
+        style={{ height: `${height}px` }}
+      >
+        {barSegments.map((segment, index) =>
+          sliceWidths[index] > 0 ? (
+            <div
+              key={segment.id}
+              className={clsx(styles.slice, styles[segment.tone])}
+              style={{ width: `${sliceWidths[index]}%` }}
+              data-testid={
+                dataTestId ? `${dataTestId}-segment-${segment.id}` : undefined
+              }
+            />
+          ) : null
+        )}
+      </div>
+      <div className={styles.legend}>
+        {segments.map((segment) => (
+          <div
+            key={segment.id}
+            className={styles.legendItem}
+            data-testid={
+              dataTestId ? `${dataTestId}-legend-${segment.id}` : undefined
+            }
+          >
+            <span className={clsx(styles.legendDot, styles[segment.tone])} />
+            <span className={styles.legendLabel}>{segment.label}</span>
+            {segment.valueDisplay ? (
+              <span className={styles.legendValue}>{segment.valueDisplay}</span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+      {errorMessage ? (
+        <div
+          className={styles.errorMessage}
+          data-testid={dataTestId ? `${dataTestId}-error` : undefined}
+          role='alert'
+        >
+          <span className={styles.errorIcon}>
+            <WarningCircleIcon
+              filled
+              size={ERROR_ICON_SIZE}
+            />
+          </span>
+          {errorMessage}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/v2/components/AllocationBar/allocationBar.module.scss
+++ b/lib/v2/components/AllocationBar/allocationBar.module.scss
@@ -1,0 +1,127 @@
+@use '../../styles/colors' as *;
+
+.allocationBar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.headerRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.label {
+  padding-left: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--gray-1000-0);
+}
+
+.totalLabel {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.track {
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  background: var(--gray-200-800);
+  border-radius: 20px;
+}
+
+.slice {
+  height: 100%;
+
+  &.used {
+    background: $fuchsia-500;
+  }
+
+  &.primary {
+    background: $cyan-600;
+  }
+
+  &.primaryLight {
+    background: $cyan-300;
+  }
+
+  &.error {
+    background: var(--error);
+  }
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  padding-left: 8px;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legendDot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+
+  &.used {
+    background: $fuchsia-500;
+  }
+
+  &.primary {
+    background: $cyan-600;
+  }
+
+  &.primaryLight {
+    background: $cyan-300;
+  }
+
+  &.free {
+    background: var(--gray-300-700);
+  }
+
+  &.error {
+    background: var(--error);
+  }
+}
+
+.legendLabel {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--gray-700-300);
+}
+
+.legendValue {
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--gray-950-20);
+}
+
+.errorMessage {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  padding: 6px 8px;
+  font-size: 12px;
+  color: $red-800;
+  background: $red-200;
+  border-radius: 4px;
+}
+
+.errorIcon {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  color: $red-700;
+}

--- a/lib/v2/components/AllocationBar/index.ts
+++ b/lib/v2/components/AllocationBar/index.ts
@@ -1,0 +1,6 @@
+export type {
+  AllocationBarProps,
+  AllocationBarSegment,
+  AllocationSegmentTone
+} from './AllocationBar'
+export { ALLOCATION_SEGMENT_TONES, AllocationBar } from './AllocationBar'

--- a/lib/v2/components/Popup/Popup.stories.tsx
+++ b/lib/v2/components/Popup/Popup.stories.tsx
@@ -16,9 +16,13 @@ const meta: Meta<typeof Popup> = {
 export default meta
 type Story = StoryObj<typeof Popup>
 
+const COLLAPSED_WIDTH = 636
+const EXPANDED_WIDTH = 1140
+
 export const Interactive: Story = {
   render: function InteractivePopup() {
     const [open, setOpen] = useState(false)
+    const [expanded, setExpanded] = useState(false)
     return (
       <>
         <Button onClick={() => setOpen(true)}>Open Popup</Button>
@@ -26,16 +30,26 @@ export const Interactive: Story = {
           onClose={() => setOpen(false)}
           open={open}
           title='Interactive Popup'
+          width={expanded ? EXPANDED_WIDTH : COLLAPSED_WIDTH}
           actions={
-            <Button
-              onClick={() => setOpen(false)}
-              variant='primary'
-            >
-              Close
-            </Button>
+            <>
+              <Button
+                onClick={() => setExpanded(!expanded)}
+                variant='secondary'
+              >
+                {expanded ? 'Collapse' : 'Expand'}
+              </Button>
+              <Button
+                onClick={() => setOpen(false)}
+                variant='primary'
+              >
+                Close
+              </Button>
+            </>
           }
         >
-          Click the close button or press Escape to close.
+          Click the close button or press Escape to close. Expand animates the
+          popup width.
         </Popup>
       </>
     )

--- a/lib/v2/components/Popup/Popup.test.tsx
+++ b/lib/v2/components/Popup/Popup.test.tsx
@@ -65,6 +65,24 @@ describe('Popup - Rendering', () => {
     expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
   })
 
+  it('applies a fixed height and fill-layout content when height is set', () => {
+    render(
+      <Popup
+        dataTestId='popup'
+        height={760}
+        onClose={vi.fn()}
+        open
+        title='Test Title'
+      >
+        Content
+      </Popup>
+    )
+
+    const modal = screen.getByTestId('popup')
+    expect(modal.style.height).toBe('760px')
+    expect(modal.querySelector('[class*="contentFill"]')).not.toBeNull()
+  })
+
   it('renders actions when provided', () => {
     render(
       <Popup

--- a/lib/v2/components/Popup/Popup.tsx
+++ b/lib/v2/components/Popup/Popup.tsx
@@ -30,6 +30,7 @@ export interface PopupProps {
   dataTestId?: string
   width?: number | string
   minWidth?: number | string
+  height?: number | string
 }
 
 export function Popup({
@@ -43,7 +44,8 @@ export function Popup({
   closeOnOverlayClick = true,
   dataTestId,
   width,
-  minWidth
+  minWidth,
+  height
 }: Readonly<PopupProps>) {
   useEffect(() => {
     if (!open) {
@@ -77,7 +79,7 @@ export function Popup({
         className={clsx(styles.modal, extraClass)}
         data-testid={dataTestId}
         onClick={(e) => e.stopPropagation()}
-        style={{ width, minWidth }}
+        style={{ width, minWidth, height }}
       >
         <div className={styles.header}>
           <h3 className={styles.title}>{title}</h3>
@@ -94,6 +96,7 @@ export function Popup({
           style={{ overflow: contentOverflow }}
           className={clsx(
             styles.content,
+            height != null && styles.contentFill,
             contentOverflow === CONTENT_OVERFLOWS.HIDDEN &&
               styles.contentNoScrollbar
           )}

--- a/lib/v2/components/Popup/popup.module.scss
+++ b/lib/v2/components/Popup/popup.module.scss
@@ -14,10 +14,12 @@
   border: 1px solid var(--gray-450-550);
   min-width: 400px;
   width: 720px;
+  max-width: calc(100vw - 48px);
   max-height: 90vh;
   display: flex;
   flex-direction: column;
   box-shadow: 0 0 16px 4px var(--popup-shadow);
+  transition: width 0.25s ease;
 }
 
 .header {
@@ -36,6 +38,7 @@
 
 .content {
   flex: 1;
+  min-height: 0;
   overflow: auto;
   scrollbar-gutter: stable both-edges;
   color: var(--text-primary);
@@ -64,6 +67,11 @@
 
 .contentNoScrollbar {
   scrollbar-gutter: auto;
+}
+
+.contentFill {
+  display: flex;
+  flex-direction: column;
 }
 
 .actions {

--- a/lib/v2/components/Switch/switch.module.scss
+++ b/lib/v2/components/Switch/switch.module.scss
@@ -57,7 +57,7 @@
 .infoIcon {
   width: 16px;
   height: 16px;
-  color: var(--gray-500);
+  color: var(--orange-500);
   transition: color 0.2s ease;
 
   &:hover {

--- a/lib/v2/components/ToggleSection/ToggleSection.stories.tsx
+++ b/lib/v2/components/ToggleSection/ToggleSection.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { useState } from 'react'
+
+import { NOOP } from '#v2/utils/consts'
+
+import { ToggleSection } from './ToggleSection'
+
+function ToggleSectionDemo() {
+  const [dataReduction, setDataReduction] = useState(false)
+  const [qos, setQos] = useState(true)
+  return (
+    <div>
+      <ToggleSection
+        checked={dataReduction}
+        label='Data Reduction'
+        onChange={setDataReduction}
+      />
+      <ToggleSection
+        checked={qos}
+        label='QoS Settings'
+        labelTooltip='Limits apply per filesystem'
+        onChange={setQos}
+      >
+        <span>Max IOPS / Max Throughput fields go here</span>
+      </ToggleSection>
+      <ToggleSection
+        checked={false}
+        disabled
+        label='Audit Logging'
+        onChange={NOOP}
+        showDivider={false}
+        switchTooltip='Enable telemetry to use audit logging'
+      />
+    </div>
+  )
+}
+
+const meta: Meta<typeof ToggleSectionDemo> = {
+  title: 'v2/ToggleSection',
+  component: ToggleSectionDemo
+}
+
+export default meta
+type Story = StoryObj<typeof ToggleSectionDemo>
+
+export const Interactive: Story = {}

--- a/lib/v2/components/ToggleSection/ToggleSection.test.tsx
+++ b/lib/v2/components/ToggleSection/ToggleSection.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ToggleSection } from './ToggleSection'
+
+const TEST_ID = 'qos-section'
+const LABEL = 'QoS Settings'
+const CONTENT_TEXT = 'Max IOPS'
+
+describe('ToggleSection', () => {
+  it('renders the label', () => {
+    render(
+      <ToggleSection
+        checked={false}
+        label={LABEL}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(LABEL)).toBeInTheDocument()
+  })
+
+  it('calls onChange with the new checked state when toggled', () => {
+    const onChange = vi.fn()
+    render(
+      <ToggleSection
+        checked={false}
+        dataTestId={TEST_ID}
+        label={LABEL}
+        onChange={onChange}
+      />
+    )
+
+    const switchInput = screen
+      .getByTestId(`${TEST_ID}-switch`)
+      .querySelector('input')
+    fireEvent.click(switchInput as HTMLInputElement)
+
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('hides children while unchecked and shows them when checked', () => {
+    const { rerender } = render(
+      <ToggleSection
+        checked={false}
+        dataTestId={TEST_ID}
+        label={LABEL}
+        onChange={vi.fn()}
+      >
+        <span>{CONTENT_TEXT}</span>
+      </ToggleSection>
+    )
+
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument()
+
+    rerender(
+      <ToggleSection
+        checked
+        dataTestId={TEST_ID}
+        label={LABEL}
+        onChange={vi.fn()}
+      >
+        <span>{CONTENT_TEXT}</span>
+      </ToggleSection>
+    )
+
+    expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument()
+  })
+
+  it('reserves no expandable area when there is no content', () => {
+    render(
+      <ToggleSection
+        checked
+        dataTestId={TEST_ID}
+        label={LABEL}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId(`${TEST_ID}-content`)).not.toBeInTheDocument()
+  })
+
+  it('reserves no expandable area when the content renders nothing', () => {
+    render(
+      <ToggleSection
+        checked
+        dataTestId={TEST_ID}
+        label={LABEL}
+        onChange={vi.fn()}
+      >
+        {null}
+      </ToggleSection>
+    )
+
+    expect(screen.queryByTestId(`${TEST_ID}-content`)).not.toBeInTheDocument()
+  })
+
+  it('disables the switch when disabled', () => {
+    render(
+      <ToggleSection
+        checked={false}
+        dataTestId={TEST_ID}
+        disabled
+        label={LABEL}
+        onChange={vi.fn()}
+      />
+    )
+
+    const switchInput = screen
+      .getByTestId(`${TEST_ID}-switch`)
+      .querySelector('input')
+    expect(switchInput).toBeDisabled()
+  })
+
+  it('renders a divider by default and omits it when showDivider is false', () => {
+    const { rerender } = render(
+      <ToggleSection
+        checked={false}
+        dataTestId={TEST_ID}
+        label={LABEL}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId(TEST_ID).className).toMatch(/divider/)
+
+    rerender(
+      <ToggleSection
+        checked={false}
+        dataTestId={TEST_ID}
+        label={LABEL}
+        onChange={vi.fn()}
+        showDivider={false}
+      />
+    )
+
+    expect(screen.getByTestId(TEST_ID).className).not.toMatch(/divider/)
+  })
+})

--- a/lib/v2/components/ToggleSection/ToggleSection.tsx
+++ b/lib/v2/components/ToggleSection/ToggleSection.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from 'react'
+
+import { Children } from 'react'
+import clsx from 'clsx'
+
+import { InfoIcon } from '../../icons'
+import { Switch } from '../Switch'
+import { Tooltip } from '../Tooltip'
+
+import styles from './toggleSection.module.scss'
+
+const TOOLTIP_ENTER_DELAY = 200
+
+export interface ToggleSectionProps {
+  label: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+  disabled?: boolean
+  labelTooltip?: string
+  switchTooltip?: string
+  children?: ReactNode
+  contentClass?: string
+  showDivider?: boolean
+  dataTestId?: string
+}
+
+/**
+ * A toggle row with a label and optional expandable content shown while the
+ * toggle is on. Controlled and presentational: the caller owns `checked`
+ * and any form state inside `children`. `labelTooltip` renders an info icon
+ * next to the label; `switchTooltip` renders the Switch's own info tooltip
+ * (typically a why-disabled explanation).
+ */
+export function ToggleSection({
+  label,
+  checked,
+  onChange,
+  disabled = false,
+  labelTooltip,
+  switchTooltip,
+  children,
+  contentClass,
+  showDivider = true,
+  dataTestId
+}: Readonly<ToggleSectionProps>) {
+  const hasContent = Children.toArray(children).length > 0
+
+  return (
+    <div
+      className={clsx(styles.toggleSection, showDivider && styles.divider)}
+      data-testid={dataTestId}
+    >
+      <div className={styles.header}>
+        <Switch
+          checked={checked}
+          dataTestId={dataTestId ? `${dataTestId}-switch` : undefined}
+          disabled={disabled}
+          onChange={(_event, isChecked) => onChange(isChecked)}
+          tooltip={switchTooltip}
+        />
+        <span className={clsx(styles.label, disabled && styles.labelDisabled)}>
+          {label}
+        </span>
+        {labelTooltip ? (
+          <Tooltip
+            data={labelTooltip}
+            enterDelay={TOOLTIP_ENTER_DELAY}
+          >
+            <span className={styles.infoIconWrapper}>
+              <InfoIcon extraClass={styles.infoIcon} />
+            </span>
+          </Tooltip>
+        ) : null}
+      </div>
+      {hasContent ? (
+        <div
+          className={clsx(
+            styles.contentGrid,
+            checked && styles.contentExpanded
+          )}
+        >
+          <div className={styles.contentClip}>
+            {checked ? (
+              <div
+                className={clsx(styles.content, contentClass)}
+                data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+              >
+                {children}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/v2/components/ToggleSection/index.ts
+++ b/lib/v2/components/ToggleSection/index.ts
@@ -1,0 +1,2 @@
+export type { ToggleSectionProps } from './ToggleSection'
+export { ToggleSection } from './ToggleSection'

--- a/lib/v2/components/ToggleSection/toggleSection.module.scss
+++ b/lib/v2/components/ToggleSection/toggleSection.module.scss
@@ -1,0 +1,54 @@
+.toggleSection {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 0 22px;
+}
+
+.divider {
+  border-bottom: 1px solid var(--gray-200-800);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--gray-650-350);
+}
+
+.labelDisabled {
+  color: var(--text-secondary);
+}
+
+.infoIconWrapper {
+  display: inline-flex;
+  align-items: center;
+}
+
+.infoIcon {
+  width: 14px;
+  height: 14px;
+  color: var(--orange-500);
+}
+
+.contentGrid {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.2s ease;
+}
+
+.contentExpanded {
+  grid-template-rows: 1fr;
+}
+
+.contentClip {
+  overflow: hidden;
+}
+
+.content {
+  padding: 20px 0 8px 44px;
+}

--- a/lib/v2/components/index.ts
+++ b/lib/v2/components/index.ts
@@ -34,6 +34,12 @@ export {
   type AlertStatusChipProps,
   type AlertStatusChipVariant
 } from './AlertStatusChip'
+export type {
+  AllocationBarProps,
+  AllocationBarSegment,
+  AllocationSegmentTone
+} from './AllocationBar'
+export { ALLOCATION_SEGMENT_TONES, AllocationBar } from './AllocationBar'
 export type { ButtonProps, ButtonType, ButtonVariant } from './Button'
 export { Button, BUTTON_TYPES, BUTTON_VARIANTS } from './Button'
 export type {
@@ -470,6 +476,8 @@ export type {
 } from './TimeRangeSelector'
 export { TimeRangeSelector } from './TimeRangeSelector'
 export { Toaster } from './Toaster'
+export type { ToggleSectionProps } from './ToggleSection'
+export { ToggleSection } from './ToggleSection'
 export type { TooltipProps } from './Tooltip'
 export { Tooltip } from './Tooltip'
 export type { WidgetCardProps } from './WidgetCard'


### PR DESCRIPTION
New v2 primitives and enhancements for the Design System 2025 **Create Filesystem** popup ([WEKAPP-661636](https://wekaio.atlassian.net/browse/WEKAPP-661636)); the wekapp dialog rebuild consuming them follows in a separate PR once this publishes.

## AllocationBar (new)
Multi-segment capacity bar, prop-only (values in plain numbers, display strings supplied by the app):
- 24px track, tone-colored segments (`used`/`primary`/`primaryLight`/`free`/`error`), widths clamped to 100%
- Header row: 14px bold `gray-1000-0` label (8px left padding) + right-aligned total
- Legend (8px left padding): 12px regular `gray-700-300` labels, 10px regular `gray-950-20` values; `free` segments appear in the legend only
- Inline over-allocation warning: `red-200` background, `red-800` text, filled 14px `red-700` warning icon, 6px/8px padding, 4px radius

## ToggleSection (new)
Controlled collapsible toggle row (composes `Switch` + `Tooltip`):
- 10px top / 22px bottom section padding, divider, 12px switch↔label gap, 14px regular `gray-650-350` label
- Animated expansion (grid-rows transition); reserves **no** expandable area when children render nothing
- `labelTooltip` / `switchTooltip` (why-disabled) / `contentClass` hooks

## Popup
- New `height` prop; a fixed-height popup lays its content out as a fill flex column (percentage heights don't resolve against a flexed content box)
- `content` gets `min-height: 0` so long children shrink into their own scroll areas instead of pushing the actions row out
- Width changes animate (`0.25s ease`) and clamp to the viewport

## Switch / ToggleSection
- Info-tooltip icons use `orange-500` per the design

## Testing
- 1810 tests pass (`yarn test:run`), including new AllocationBar/ToggleSection suites and a Popup fixed-height case
- ESLint / Prettier / Stylelint clean on changed files; `yarn build` green; no new typecheck errors vs main
- Visually verified in Storybook and live against a dev cluster through the rebuilt wekapp dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEKAPP-661636]: https://wekaio.atlassian.net/browse/WEKAPP-661636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ